### PR TITLE
improve redirect support for dynamic url

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -80,7 +80,7 @@ function Zlibrary:addToMainMenu(menu_items)
                                 Ui.showGenericInputDialog(
                                     T("Set base URL"),
                                     Config.SETTINGS_BASE_URL_KEY,
-                                    Config.getBaseUrl(),
+                                    Config.getBaseUrl(true),
                                     false,
                                     function(input_value)
                                         local success, err_msg = Config.setAndValidateBaseUrl(input_value)

--- a/zlibrary/api.lua
+++ b/zlibrary/api.lua
@@ -70,7 +70,7 @@ local function _checkAndHandleRedirect(current_url)
     repeat
         local request_params = {
             url = real_url,
-            method = "HEAD",
+            method = method,
             redirect = false
         }
         

--- a/zlibrary/api.lua
+++ b/zlibrary/api.lua
@@ -179,8 +179,8 @@ function Api.makeHttpRequest(options)
     local check_result = _checkAndHandleRedirect(is_skip_check, result.status_code, options.url)
     if check_result.has_redirect then
         if check_result.real_url then
-            options.getRedirectedUrl = nil
             options.url = options.getRedirectedUrl()
+            options.getRedirectedUrl = nil
             return Api.makeHttpRequest(options)
         elseif check_result.error then
             result = check_result

--- a/zlibrary/cache.lua
+++ b/zlibrary/cache.lua
@@ -71,8 +71,9 @@ function Cache:get(key, cache_expiry)
     if expiry <= 0 then
         return nil
     end
+    uptime = tonumber(uptime)
     if not uptime or (os.time() - uptime > expiry) then
-        self._cache:delSetting(key)
+        self:remove(key)
         return nil
     end
 

--- a/zlibrary/cache.lua
+++ b/zlibrary/cache.lua
@@ -105,7 +105,9 @@ function Cache:remove(key)
     if not self._cache.delSetting then
         return nil
     end
+    local uptime_key = key .. "_ut"
     self._cache:delSetting(key)
+    self._cache:delSetting(uptime_key):flush()
     return true
 end
 

--- a/zlibrary/config.lua
+++ b/zlibrary/config.lua
@@ -27,6 +27,7 @@ Config.CREDENTIALS_FILENAME = "zlibrary_credentials.lua"
 
 Config.DEFAULT_DOWNLOAD_DIR_FALLBACK = G_reader_settings:readSetting("home_dir")
              or require("apps/filemanager/filemanagerutil").getDefaultDir()
+Config.USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36"
 Config.SEARCH_RESULTS_LIMIT = 30
 
 -- Timeout configuration for different operations (block_timeout, total_timeout)

--- a/zlibrary/config.lua
+++ b/zlibrary/config.lua
@@ -140,7 +140,7 @@ function Config.getCacheRealUrl()
     local runtime_cache = Cache:new{
         name = "_runtime_cache"
     }
-    local api_real_url = runtime_cache:get("api_real_url", 1200)
+    local api_real_url = runtime_cache:get("api_real_url", 1800)
     return api_real_url and api_real_url[1]
 end
 

--- a/zlibrary/config.lua
+++ b/zlibrary/config.lua
@@ -140,7 +140,7 @@ function Config.getCacheRealUrl()
     local runtime_cache = Cache:new{
         name = "_runtime_cache"
     }
-    local api_real_url = runtime_cache:get("api_real_url", 1800)
+    local api_real_url = runtime_cache:get("api_real_url", 600)
     return api_real_url and api_real_url[1]
 end
 

--- a/zlibrary/ota.lua
+++ b/zlibrary/ota.lua
@@ -95,6 +95,7 @@ function Ota.fetchLatestReleaseInfo()
             ["Accept"] = "application/vnd.github.v3+json",
         },
         timeout = 20,
+        redirect = true,
     }
 
     local http_result = Api.makeHttpRequest(http_options)
@@ -147,6 +148,7 @@ function Ota.downloadUpdate(url, destination_path)
         headers = { ["User-Agent"] = "KOReader-ZLibrary-Plugin" },
         sink = sink,
         timeout = 300,
+        redirect = true,
     }
 
     local http_result = Api.makeHttpRequest(http_options)


### PR DESCRIPTION
initial version, attempting to address multiple redirects of dynamic URLs.   #81  #86
The principle is that when a redirect HTTP status code is detected, the final destination URL is queried and the request is retried.

- Test mirror site：

    - zlib.fi
    - fuckfbi.ru
    - zlib.by
    - zlib.icu
    - z-lib.su
    - z-lib.hk
    - 1lib.sk
    - 1lib.su
    - 101ml.fi
    - 101ml.ru
    - 101ml.su
    - 101ml.gs

supports fixing 301/302 errors from interface redirects.
cannot handle mirror sites that are protected by Cloudflare's CAPTCHA challenge, such as `z-lib.fm`.