### PR TITLE
add real url reset description

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -77,6 +77,7 @@ function Zlibrary:addToMainMenu(menu_items)
                             text = T("Set base URL"),
                             keep_menu_open = true,
                             callback = function()
+                                local real_url = Config.getCacheRealUrl()
                                 Ui.showGenericInputDialog(
                                     T("Set base URL"),
                                     Config.SETTINGS_BASE_URL_KEY,
@@ -89,7 +90,8 @@ function Zlibrary:addToMainMenu(menu_items)
                                             return false
                                         end
                                         return true
-                                    end
+                                    end,
+                                    real_url and string.format(T("*Current base URL redirected to %s. Click Set to update the target."), real_url)
                                 )
                             end,
                             separator = true,
@@ -412,7 +414,7 @@ function Zlibrary:onSelectRecommendedBook(book_stub)
     local book_cache = Cache:new{
             name = string.format("%s_%s", book_stub.id, book_stub.hash)
     }
-    local book_details_cache = book_cache:get("details")
+    local book_details_cache = book_cache:get("details", 1800)
 
     if type(book_details_cache) == "table" and book_details_cache.title then
         Ui.showBookDetails(self, book_details_cache, function()

--- a/zlibrary/config.lua
+++ b/zlibrary/config.lua
@@ -141,7 +141,7 @@ function Config.getCacheRealUrl()
     local runtime_cache = Cache:new{
         name = "_runtime_cache"
     }
-    local api_real_url = runtime_cache:get("api_real_url", 600)
+    local api_real_url = runtime_cache:get("api_real_url", 43200)
     return api_real_url and api_real_url[1]
 end
 
@@ -157,7 +157,7 @@ function Config.setCacheRealUrl(original_url, real_url)
         return
     end
     
-    local base_url = Config.getBaseUrl(true)
+    local base_url = Config.getBaseUrl()
     if not (base_url and string.find(original_url, base_url, 1, true)) then
         return
     end

--- a/zlibrary/ui.lua
+++ b/zlibrary/ui.lua
@@ -271,11 +271,12 @@ function Ui.showOrdersSelectionDialog(parent_ui, ok_callback)
     _showRadioSelectionDialog(parent_ui, T("Select search order"), Config.SETTINGS_SEARCH_ORDERS_KEY, Config.SUPPORTED_ORDERS, ok_callback)
 end
 
-function Ui.showGenericInputDialog(title, setting_key, current_value_or_default, is_password, validate_and_save_callback)
+function Ui.showGenericInputDialog(title, setting_key, current_value_or_default, is_password, validate_and_save_callback, description)
     local dialog
 
     dialog = InputDialog:new{
         title = title,
+        description = description,
         input = current_value_or_default or "",
         text_type = is_password and "password" or nil,
         buttons = {{


### PR DESCRIPTION
Add a description to the Base Url settings for easy status viewing.

<p style="text-align: center;">
  <img src="https://github.com/user-attachments/assets/b6991620-394c-4757-8a6e-3f7dbb9db82c" alt="Demo screenshot" width="200">
</p>
