### PR TITLE
feat: Add book cover thumbnails with sync pre-download

### DIFF
--- a/_meta.lua
+++ b/_meta.lua
@@ -3,5 +3,5 @@ return {
     name = "zlibrary",
     fullname = T("Z-library"),
     description = T("[[A plugin to search and download books from Z-library.]]"),
-    version = "1.0.29",
+    version = "1.0.30",
 }

--- a/main.lua
+++ b/main.lua
@@ -52,6 +52,9 @@ function Zlibrary:init()
     end
 
     self._runtime_cache = Cache:new({name = "_runtime_cache"})
+
+    -- Limpieza silenciosa de covers antiguos (>7 días)
+    pcall(Cache.cleanOldCovers, 7)
 end
 
 function Zlibrary:onZlibrarySearch()
@@ -339,7 +342,12 @@ function Zlibrary:_requestDispatcher(options, ...)
 
 
         local task = function()
-            return options.api_method(user_session and user_session.user_id, user_session and user_session.user_key, table.unpack(api_extra_params))
+            local api_result = options.api_method(user_session and user_session.user_id, user_session and user_session.user_key, table.unpack(api_extra_params))
+            -- Hook opcional: pre-procesar resultado (ej. pre-descargar portadas)
+            if type(options.prefetch_task) == "function" then
+                pcall(options.prefetch_task, api_result)
+            end
+            return api_result
         end
 
         local on_success = function(api_result)
@@ -407,6 +415,14 @@ function Zlibrary:_fetchBookList(options, ...)
     options.hasValidApiResult = function(api_result)
         local ok = type(api_result) == "table" and type(api_result.books) == "table" and #api_result.books > 0
         return ok, not ok and T("No books found, please try again")
+    end
+    -- Pre-descargar portadas antes de mostrar el menú
+    if not options.prefetch_task then
+        options.prefetch_task = function(api_result)
+            if api_result and api_result.books then
+                Ui.prefetchCoversSync(api_result.books, 50)
+            end
+        end
     end
     options.resolve_result = function(ui_self, api_result, plugin_self)
         
@@ -626,6 +642,11 @@ function Zlibrary:showMyBooksDialog(def_position, def_search_input)
                         operation_name = T("Downloaded books"),
                         log_context = "onShowDownloadedBooks",
                         hasValidApiResult = valid_api_result,
+                        prefetch_task = function(api_result)
+                            if api_result and api_result.books then
+                                Ui.prefetchCoversSync(api_result.books, 50)
+                            end
+                        end,
                         resolve_result = function(ui_self, api_result, plugin_self)
                             local books = api_result.books
                             local current_page = page or 1
@@ -659,6 +680,11 @@ function Zlibrary:showMyBooksDialog(def_position, def_search_input)
                         operation_name = T("Favorite books"),
                         log_context = "onShowFavoriteBooks",
                         hasValidApiResult = valid_api_result,
+                        prefetch_task = function(api_result)
+                            if api_result and api_result.books then
+                                Ui.prefetchCoversSync(api_result.books, 50)
+                            end
+                        end,
                         resolve_result = function(ui_self, api_result, plugin_self)
                             local books = api_result.books
                             local current_page = page or 1
@@ -950,7 +976,12 @@ function Zlibrary:performSearch(query)
         local current_page_to_search = 1
 
         local task = function()
-            return Api.search(query, user_session and user_session.user_id, user_session and user_session.user_key, selected_languages, selected_extensions, selected_order, current_page_to_search)
+            local api_result = Api.search(query, user_session and user_session.user_id, user_session and user_session.user_key, selected_languages, selected_extensions, selected_order, current_page_to_search)
+            -- Pre-descargar portadas antes de devolver los resultados
+            if api_result and api_result.results and #api_result.results > 0 then
+                Ui.prefetchCoversSync(api_result.results, 50)
+            end
+            return api_result
         end
 
         local on_success
@@ -1051,7 +1082,12 @@ function Zlibrary:displaySearchResults(initial_book_data_list, query_string)
             local selected_order_more = Config.getSearchOrder()
 
             local task_load_more = function()
-                return Api.search(self.current_search_query, user_session_more.user_id, user_session_more.user_key, selected_languages_more, selected_extensions_more, selected_order_more, next_api_page_to_fetch)
+                local api_result_more = Api.search(self.current_search_query, user_session_more.user_id, user_session_more.user_key, selected_languages_more, selected_extensions_more, selected_order_more, next_api_page_to_fetch)
+                -- Pre-descargar portadas de la nueva página
+                if api_result_more and api_result_more.results and #api_result_more.results > 0 then
+                    Ui.prefetchCoversSync(api_result_more.results, 50)
+                end
+                return api_result_more
             end
 
             local on_success_load_more

--- a/main.lua
+++ b/main.lua
@@ -708,31 +708,6 @@ function Zlibrary:showMyBooksDialog(def_position, def_search_input)
         my_books_dialog:fetchAndShow()
 end
 
-function Zlibrary:onShowRecommendedBooks()
-    self:_fetchBookList({
-        api_method = Api.getRecommendedBooks,
-        loading_text_key = T("Fetching recommended books..."),
-        error_prefix_key = T("Failed to fetch recommended books"),
-        operation_name = T("Recommended books"),
-        log_context = "onShowRecommendedBooks",
-        results_member_name = "current_recommended_books",
-        display_menu_func = Ui.showRecommendedBooksMenu,
-        requires_auth = true
-    })
-end
-
-function Zlibrary:onShowMostPopularBooks()
-    self:_fetchBookList({
-        api_method = Api.getMostPopularBooks,
-        loading_text_key = T("Fetching most popular books..."),
-        error_prefix_key = T("Failed to fetch most popular books"),
-        operation_name = T("Most popular books"),
-        log_context = "onShowMostPopularBooks",
-        results_member_name = "current_most_popular_books",
-        display_menu_func = Ui.showMostPopularBooksMenu,
-        requires_auth = false
-    })
-end
 
 function Zlibrary:searchSimilarBooks(book_stub)
     if not (book_stub.id and book_stub.hash) then
@@ -1315,30 +1290,23 @@ end
 
 function Zlibrary:downloadAndShowCover(book)
     local cover_url = book.cover
-    local book_id = book.id
     local book_hash = book.hash
     local book_title = book.title
 
-    if not (cover_url and book_id and book_hash) then
+    if not (cover_url and book_hash) then
         logger.warn("Zlibrary:downloadAndShowCover - parameter error")
         return
     end
 
-    local function getImgExtension(url)
-       local clean_url = url:match("^([^%?]+)") or url
-       return clean_url:match("[%.]([^%.]+)$") or "jpg"
-    end
-
-    local cover_ext = getImgExtension(cover_url)
-    local cache_path = Cache:makePath(book_id, book_hash)
-    local cover_cache_path = string.format("%s.%s", cache_path, cover_ext)
+    -- Use the unified cover cache path (same as prefetchCoversSync and menu.lua)
+    local cover_cache_path = Cache.getCoverPath(book_hash)
+    if not cover_cache_path then return end
 
     if not util.fileExists(cover_cache_path) then
+        pcall(Cache.ensureCoversDir)
         local download_result = Api.downloadBookCover(cover_url, cover_cache_path)
         if download_result.error or not download_result.success then
-            if util.fileExists(cover_cache_path) then
-                    pcall(os.remove, cover_cache_path)
-            end
+            pcall(os.remove, cover_cache_path)
             Ui.showErrorMessage(tostring(download_result.error))
             return
         end

--- a/zlibrary/api.lua
+++ b/zlibrary/api.lua
@@ -143,8 +143,66 @@ local function _extractErrorFromJsonBody(body)
     return nil
 end
 
+--- Builds standard authenticated headers for Z-library API requests.
+--- @param user_id string|nil User ID for authentication
+--- @param user_key string|nil User key for authentication
+--- @return table Headers table
+local function _buildAuthHeaders(user_id, user_key)
+    local headers = {
+        ['Content-Type'] = 'application/x-www-form-urlencoded',
+        ["User-Agent"] = Config.USER_AGENT,
+    }
+    if user_id and user_key then
+        headers["Cookie"] = string.format("remix_userid=%s; remix_userkey=%s", user_id, user_key)
+    end
+    return headers
+end
+
+--- Common pattern for authenticated GET requests that return JSON.
+--- Handles URL check, headers, HTTP request, body check, and JSON parsing.
+--- @param url string|nil The API endpoint URL
+--- @param user_id string|nil User ID for authentication
+--- @param user_key string|nil User key for authentication
+--- @param timeout table|number|nil Request timeout configuration
+--- @param getRedirectedUrl function|nil URL factory for redirect handling
+--- @param log_context string Name of the calling function for logging
+--- @return table|nil Parsed JSON data on success
+--- @return string|nil Error message on failure
+local function _authenticatedJsonGet(url, user_id, user_key, timeout, getRedirectedUrl, log_context)
+    if not url then
+        logger.warn("Api.", log_context, " - URL not configured")
+        return nil, T("Z-library server URL not configured.")
+    end
+
+    local http_result = Api.makeHttpRequest{
+        url = url,
+        method = "GET",
+        headers = _buildAuthHeaders(user_id, user_key),
+        timeout = timeout or Config.getPopularTimeout(),
+        getRedirectedUrl = getRedirectedUrl,
+    }
+
+    if http_result.error then
+        logger.warn("Api.", log_context, " - HTTP error: ", http_result.error)
+        return nil, http_result.error
+    end
+
+    if not http_result.body then
+        logger.warn("Api.", log_context, " - No response body")
+        return nil, T("No response body received.")
+    end
+
+    local ok, data = pcall(json.decode, http_result.body, json.decode.simple)
+    if not ok or not data then
+        logger.warn("Api.", log_context, " - JSON decode failed")
+        return nil, T("Failed to parse response.")
+    end
+
+    return data, nil
+end
+
 function Api.makeHttpRequest(options)
-    logger.dbg(string.format("Zlibrary:Api.makeHttpRequest - START - URL: %s, Method: %s", options.url, options.method or "GET"))
+    logger.dbg("Api.makeHttpRequest - START -", options.url, options.method or "GET")
     
     local response_body_table = {}
     local result = { body = nil, status_code = nil, error = nil, headers = nil }
@@ -158,10 +216,8 @@ function Api.makeHttpRequest(options)
     if options.timeout then
         if type(options.timeout) == "table" then
             socketutil:set_timeout(options.timeout[1], options.timeout[2])
-            logger.dbg(string.format("Zlibrary:Api.makeHttpRequest - Setting timeout to %s/%s seconds", options.timeout[1], options.timeout[2]))
         else
             socketutil:set_timeout(options.timeout)
-            logger.dbg(string.format("Zlibrary:Api.makeHttpRequest - Setting timeout to %s seconds", options.timeout))
         end
     end
 
@@ -175,17 +231,11 @@ function Api.makeHttpRequest(options)
         redirect = options.redirect or false,
     }
 
-    logger.dbg(string.format("Zlibrary:Api.makeHttpRequest - Request Params: URL: %s, Method: %s, Timeout: %s", request_params.url, request_params.method, tostring(options.timeout)))
-
     local req_ok, r_val, r_code, r_headers_tbl, r_status_str = pcall(http.request, request_params)
     
     if options.timeout then
         socketutil:reset_timeout()
-        logger.dbg("Zlibrary:Api.makeHttpRequest - Reset timeout to default")
     end
-
-    logger.dbg(string.format("Zlibrary:Api.makeHttpRequest - pcall result: ok=%s, r_val=%s (type %s), r_code=%s (type %s), r_headers_tbl type=%s, r_status_str=%s",
-        tostring(req_ok), tostring(r_val), type(r_val), tostring(r_code), type(r_code), type(r_headers_tbl), tostring(r_status_str)))
 
     if not req_ok then
         local error_msg = tostring(r_val)
@@ -246,8 +296,7 @@ function Api.makeHttpRequest(options)
         end
     end
 
-    logger.dbg(string.format("Zlibrary:Api.makeHttpRequest - END - Status: %s, Headers found: %s, Error: %s",
-        result.status_code, tostring(result.headers ~= nil), tostring(result.error)))
+    logger.dbg("Api.makeHttpRequest - END - Status:", result.status_code, "Error:", result.error)
     return result
 end
 
@@ -571,212 +620,69 @@ function Api.downloadBookCover(download_url, target_filepath)
 end
 
 function Api.getRecommendedBooks(user_id, user_key)
-    local url = Config.getRecommendedBooksUrl()
-    if not url then
-        logger.warn("Api.getRecommendedBooks - Base URL not configured")
-        return { error = T("Z-library server URL not configured.") }
-    end
-
-    local headers = {
-        ['Content-Type'] = 'application/x-www-form-urlencoded',
-        ["User-Agent"] = Config.USER_AGENT,
-    }
-    if user_id and user_key then
-        headers["Cookie"] = string.format("remix_userid=%s; remix_userkey=%s", user_id, user_key)
-    end
-    
-    local http_result = Api.makeHttpRequest{
-        url = url,
-        method = "GET",
-        headers = headers,
-        timeout = Config.getRecommendedTimeout(),
-        getRedirectedUrl = Config.getRecommendedBooksUrl,
-    }
-    
-    if http_result.error then
-        logger.warn("Api.getRecommendedBooks - HTTP request error: ", http_result.error)
-        return { error = http_result.error }
-    end
-
-    if not http_result.body then
-        logger.warn("Api.getRecommendedBooks - No response body")
-        return { error = T("Failed to fetch recommended books (no response body).") }
-    end
-
-    local success, data = pcall(json.decode, http_result.body, json.decode.simple)
-    if not success or not data then
-        logger.warn("Api.getRecommendedBooks - Failed to decode JSON: ", http_result.body)
-        return { error = T("Failed to parse recommended books response.") }
-    end
+    local data, err = _authenticatedJsonGet(
+        Config.getRecommendedBooksUrl(), user_id, user_key,
+        Config.getRecommendedTimeout(), Config.getRecommendedBooksUrl,
+        "getRecommendedBooks")
+    if not data then return { error = err } end
 
     if data.success ~= 1 or not data.books then
-        logger.warn("Api.getRecommendedBooks - API error: ", http_result.body)
         return { error = data.message or T("API returned an error for recommended books.") }
     end
-    
-    local transformed_books = _transformApiBookData(data.books)
-    return { books = transformed_books }
+    return { books = _transformApiBookData(data.books) }
 end
 
 function Api.getMostPopularBooks(user_id, user_key)
-    local url = Config.getMostPopularBooksUrl()
-    if not url then
-        logger.warn("Api.getMostPopularBooks - Base URL not configured")
-        return { error = T("Z-library server URL not configured.") }
-    end
-
-    local headers = {
-        ['Content-Type'] = 'application/x-www-form-urlencoded',
-        ["User-Agent"] = Config.USER_AGENT,
-    }
-    if user_id and user_key then
-        headers["Cookie"] = string.format("remix_userid=%s; remix_userkey=%s", user_id, user_key)
-    end
-
-    local http_result = Api.makeHttpRequest{
-        url = url,
-        method = "GET",
-        headers = headers,
-        timeout = Config.getPopularTimeout(),
-        getRedirectedUrl = Config.getMostPopularBooksUrl,
-    }
-
-    if http_result.error then
-        logger.warn("Api.getMostPopularBooks - HTTP request error: ", http_result.error)
-        return { error = http_result.error }
-    end
-
-    if not http_result.body then
-        logger.warn("Api.getMostPopularBooks - No response body")
-        return { error = T("Failed to fetch most popular books (no response body).") }
-    end
-
-    local success, data = pcall(json.decode, http_result.body, json.decode.simple)
-    if not success or not data then
-        logger.warn("Api.getMostPopularBooks - Failed to decode JSON: ", http_result.body)
-        return { error = T("Failed to parse most popular books response.") }
-    end
+    local data, err = _authenticatedJsonGet(
+        Config.getMostPopularBooksUrl(), user_id, user_key,
+        Config.getPopularTimeout(), Config.getMostPopularBooksUrl,
+        "getMostPopularBooks")
+    if not data then return { error = err } end
 
     if data.success ~= 1 or not data.books then
-        logger.warn("Api.getMostPopularBooks - API error: ", http_result.body)
         return { error = data.message or T("API returned an error for most popular books.") }
     end
-
-    local transformed_books = _transformApiBookData(data.books)
-    return { books = transformed_books }
+    return { books = _transformApiBookData(data.books) }
 end
 
 function Api.getBookDetails(user_id, user_key, book_id, book_hash)
-    local url = Config.getBookDetailsUrl(book_id, book_hash)
-    if not url then
-        logger.warn("Api.getBookDetails - URL could not be constructed. Base URL configured? Book ID/Hash provided?")
-        return { error = T("Z-library server URL not configured or book identifiers missing.") }
-    end
-
-    local headers = {
-        ["User-Agent"] = Config.USER_AGENT,
-        ['Content-Type'] = 'application/x-www-form-urlencoded',
-    }
-    if user_id and user_key then
-        headers["Cookie"] = string.format("remix_userid=%s; remix_userkey=%s", user_id, user_key)
-    end
-
-    local http_result = Api.makeHttpRequest{
-        url = url,
-        method = "GET",
-        headers = headers,
-        timeout = Config.getBookDetailsTimeout(),
-        getRedirectedUrl = function()
-            return Config.getBookDetailsUrl(book_id, book_hash)
-        end,
-    }
-
-    if http_result.error then
-        logger.warn("Api.getBookDetails - HTTP request error: ", http_result.error)
-        return { error = http_result.error }
-    end
-
-    if not http_result.body then
-        logger.warn("Api.getBookDetails - No response body")
-        return { error = T("Failed to fetch book details (no response body).") }
-    end
-
-    local success, data = pcall(json.decode, http_result.body, json.decode.simple)
-    if not success or not data then
-        logger.warn("Api.getBookDetails - Failed to decode JSON: ", http_result.body)
-        return { error = T("Failed to parse book details response.") }
-    end
+    local data, err = _authenticatedJsonGet(
+        Config.getBookDetailsUrl(book_id, book_hash), user_id, user_key,
+        Config.getBookDetailsTimeout(),
+        function() return Config.getBookDetailsUrl(book_id, book_hash) end,
+        "getBookDetails")
+    if not data then return { error = err } end
 
     if data.success ~= 1 or not data.book then
-        logger.warn("Api.getBookDetails - API error: ", http_result.body)
         return { error = data.message or T("API returned an error for book details.") }
     end
 
     local transformed_book = _transformApiBookData(data.book)
     if not transformed_book then
-        logger.warn("Api.getBookDetails - Failed to transform book data: ", data.book.id)
         return { error = T("Failed to process book details.") }
     end
-
     return { book = transformed_book }
 end
 
 function Api.getDownloadLink(user_id, user_key, book_id, book_hash)
-    local url = Config.getDownloadLinkUrl(book_id, book_hash)
-    if not url then
-        logger.warn("Api.getDownloadLink - URL could not be constructed. Base URL configured? Book ID/Hash provided?")
-        return { error = T("Z-library server URL not configured or book identifiers missing.") }
-    end
-
-    local headers = {
-        ["User-Agent"] = Config.USER_AGENT,
-        ['Content-Type'] = 'application/x-www-form-urlencoded',
-    }
-    if user_id and user_key then
-        headers["Cookie"] = string.format("remix_userid=%s; remix_userkey=%s", user_id, user_key)
-    end
-
-    local http_result = Api.makeHttpRequest{
-        url = url,
-        method = "GET",
-        headers = headers,
-        timeout = Config.getBookDetailsTimeout(),
-        getRedirectedUrl = function()
-            return Config.getDownloadLinkUrl(book_id, book_hash)
-        end,
-    }
-
-    if http_result.error then
-        logger.warn("Api.getDownloadLink - HTTP request error: ", http_result.error)
-        return { error = http_result.error }
-    end
-
-    if not http_result.body then
-        logger.warn("Api.getDownloadLink - No response body")
-        return { error = T("Failed to fetch download link (no response body).") }
-    end
-
-    local success, data = pcall(json.decode, http_result.body, json.decode.simple)
-    if not success or not data then
-        logger.warn("Api.getDownloadLink - Failed to decode JSON: ", http_result.body)
-        return { error = T("Failed to parse download link response.") }
-    end
+    local data, err = _authenticatedJsonGet(
+        Config.getDownloadLinkUrl(book_id, book_hash), user_id, user_key,
+        Config.getBookDetailsTimeout(),
+        function() return Config.getDownloadLinkUrl(book_id, book_hash) end,
+        "getDownloadLink")
+    if not data then return { error = err } end
 
     if data.success ~= 1 or not data.file then
-        logger.warn("Api.getDownloadLink - API error: ", http_result.body)
-        return { error = data.message or T("API returned an error for download link.") }
+        return { error = data.message or T("No download link provided in API response.") }
     end
 
     local file_data = data.file
-    local download_link = file_data.downloadLink
-    
-    if not download_link then
-        logger.warn("Api.getDownloadLink - No download link in response: ", http_result.body)
+    if not file_data.downloadLink then
         return { error = T("No download link provided in API response.") }
     end
 
     return {
-        download_link = download_link,
+        download_link = file_data.downloadLink,
         description = file_data.description,
         author = file_data.author,
         extension = file_data.extension,
@@ -785,361 +691,115 @@ function Api.getDownloadLink(user_id, user_key, book_id, book_hash)
 end
 
 function Api.getSimilarBooks(user_id, user_key, book_id, book_hash)
-    local url = Config.getSimilarBooksUrl(book_id, book_hash)
-    if not url then
-        logger.warn("Api.getSimilarBooks - Base URL not configured")
-        return { error = T("Z-library server URL not configured.") }
-    end
-
-    local headers = {
-        ['Content-Type'] = 'application/x-www-form-urlencoded',
-        ["User-Agent"] = Config.USER_AGENT,
-    }
-    if user_id and user_key then
-        headers["Cookie"] = string.format("remix_userid=%s; remix_userkey=%s", user_id, user_key)
-    end
-
-    local http_result = Api.makeHttpRequest{
-        url = url,
-        method = "GET",
-        headers = headers,
-        timeout = Config.getPopularTimeout(),
-        getRedirectedUrl = function()
-            return Config.getSimilarBooksUrl(book_id, book_hash)
-        end,
-    }
-
-    if http_result.error then
-        logger.warn("Api.getSimilarBooks - HTTP request error: ", http_result.error)
-        return { error = http_result.error }
-    end
-
-    if not http_result.body then
-        logger.warn("Api.getSimilarBooks - No response body")
-        return { error = T("Failed to fetch similar books (no response body).") }
-    end
-
-    local success, data = pcall(json.decode, http_result.body, json.decode.simple)
-    if not success or not data then
-        logger.warn("Api.getSimilarBooks - Failed to decode JSON: ", http_result.body)
-        return { error = T("Failed to parse similar books response.") }
-    end
+    local data, err = _authenticatedJsonGet(
+        Config.getSimilarBooksUrl(book_id, book_hash), user_id, user_key,
+        Config.getPopularTimeout(),
+        function() return Config.getSimilarBooksUrl(book_id, book_hash) end,
+        "getSimilarBooks")
+    if not data then return { error = err } end
 
     if data.success ~= 1 or not data.books then
-        logger.warn("Api.getSimilarBooks - API error: ", http_result.body)
         return { error = data.message or T("API returned an error for similar books.") }
     end
-
-    local transformed_books = _transformApiBookData(data.books)
-    return { books = transformed_books }
+    return { books = _transformApiBookData(data.books) }
 end
 
 function Api.getDownloadedBooks(user_id, user_key, page, order)
-
     page = page or 1
 
-    local url = Config.getDownloadedBooksUrl(page, order)
-    if not url then
-        logger.warn("Api.getDownloadedBooks - Base URL not configured")
-        return { error = T("Z-library server URL not configured.") }
-    end
+    local data, err = _authenticatedJsonGet(
+        Config.getDownloadedBooksUrl(page, order), user_id, user_key,
+        Config.getPopularTimeout(),
+        function() return Config.getDownloadedBooksUrl(page, order) end,
+        "getDownloadedBooks")
+    if not data then return { error = err } end
 
-    local headers = {
-        ['Content-Type'] = 'application/x-www-form-urlencoded',
-        ["User-Agent"] = Config.USER_AGENT,
-    }
-    if user_id and user_key then
-        headers["Cookie"] = string.format("remix_userid=%s; remix_userkey=%s", user_id, user_key)
-    end
-
-    local http_result = Api.makeHttpRequest{
-        url = url,
-        method = "GET",
-        headers = headers,
-        timeout = Config.getPopularTimeout(),
-        getRedirectedUrl = function()
-            return Config.getDownloadedBooksUrl(page, order)
-        end,
-    }
-
-    if http_result.error then
-        logger.warn("Api.getDownloadedBooks - HTTP request error: ", http_result.error)
-        return { error = http_result.error }
-    end
-
-    if not http_result.body then
-        logger.warn("Api.getDownloadedBooks - No response body")
-        return { error = T("Failed to fetch downloaded books (no response body).") }
-    end
-
-    -- Get nil instead of functions for 'null' by using JSON.decode.simple
-    local success, data = pcall(json.decode, http_result.body, json.decode.simple)
-    if not success or not data then
-        logger.warn("Api.getDownloadedBooks - Failed to decode JSON: ", http_result.body)
-        return { error = T("Failed to parse downloaded books response.") }
-    end
-     
     if not (data.success == 1 and data.books and type(data.pagination) == "table") then
-        logger.warn("Api.getDownloadedBooks - API error: ", http_result.body)
         return { error = data.message or T("API returned an error for downloaded books.") }
     end
 
     local pagination = data.pagination
-    local has_more_results = type(data.books) == "table" and #data.books > 0 
-    and pagination.total_pages and pagination.current 
-    and page == pagination.current and pagination.current < pagination.total_pages
+    local has_more_results = type(data.books) == "table" and #data.books > 0
+        and pagination.total_pages and pagination.current
+        and page == pagination.current and pagination.current < pagination.total_pages
 
-    local transformed_books = _transformApiBookData(data.books)
-    return { has_more_results = has_more_results, books = transformed_books }
+    return { has_more_results = has_more_results, books = _transformApiBookData(data.books) }
 end
 
 function Api.getFavoriteBooks(user_id, user_key, page, order)
-
     page = page or 1
-    
-    local url = Config.getFavoriteBooksUrl(page, order)
-    if not url then
-        logger.warn("Api.getFavoriteBooks - Base URL not configured")
-        return { error = T("Z-library server URL not configured.") }
-    end
 
-    local headers = {
-        ['Content-Type'] = 'application/x-www-form-urlencoded',
-        ["User-Agent"] = Config.USER_AGENT,
-    }
-    if user_id and user_key then
-        headers["Cookie"] = string.format("remix_userid=%s; remix_userkey=%s", user_id, user_key)
-    end
-
-    local http_result = Api.makeHttpRequest{
-        url = url,
-        method = "GET",
-        headers = headers,
-        timeout = Config.getPopularTimeout(),
-        getRedirectedUrl = function()
-            return Config.getFavoriteBooksUrl(page, order)
-        end,
-    }
-    
-    if http_result.error then
-        logger.warn("Api.getFavoriteBooks - HTTP request error: ", http_result.error)
-        return { error = http_result.error }
-    end
-
-    if not http_result.body then
-        logger.warn("Api.getFavoriteBooks - No response body")
-        return { error = T("Failed to fetch favorite books (no response body).") }
-    end
-
-    local success, data = pcall(json.decode, http_result.body, json.decode.simple)
-    if not success or not data then
-        logger.warn("Api.getFavoriteBooks - Failed to decode JSON: ", http_result.body)
-        return { error = T("Failed to parse favorite books response.") }
-    end
+    local data, err = _authenticatedJsonGet(
+        Config.getFavoriteBooksUrl(page, order), user_id, user_key,
+        Config.getPopularTimeout(),
+        function() return Config.getFavoriteBooksUrl(page, order) end,
+        "getFavoriteBooks")
+    if not data then return { error = err } end
 
     if not (data.success == 1 and data.books and data.pagination) then
-        logger.warn("Api.getFavoriteBooks - API error: ", http_result.body)
         return { error = data.message or T("API returned an error for favorite books.") }
     end
-    
-    local pagination = data.pagination
-    local has_more_results = type(data.books) == "table" and #data.books > 0 
-    and pagination.total_pages and pagination.current 
-    and page == pagination.current and pagination.current < pagination.total_pages
 
-    local transformed_books = _transformApiBookData(data.books)
-    return { has_more_results = has_more_results, books = transformed_books }
+    local pagination = data.pagination
+    local has_more_results = type(data.books) == "table" and #data.books > 0
+        and pagination.total_pages and pagination.current
+        and page == pagination.current and pagination.current < pagination.total_pages
+
+    return { has_more_results = has_more_results, books = _transformApiBookData(data.books) }
 end
 
 function Api.unfavoriteBook(user_id, user_key, book_stub)
-    local url = Config.getUnFavoriteUrl(book_stub.id)
-    if not url then
-        logger.warn("Api.unfavoriteBook - Base URL not configured")
-        return { error = T("Z-library server URL not configured.") }
-    end
-
-    local headers = {
-        ['Content-Type'] = 'application/x-www-form-urlencoded',
-        ["User-Agent"] = Config.USER_AGENT,
-    }
-    if user_id and user_key then
-        headers["Cookie"] = string.format("remix_userid=%s; remix_userkey=%s", user_id, user_key)
-    end
-
-    local http_result = Api.makeHttpRequest{
-        url = url,
-        method = "GET",
-        headers = headers,
-        timeout = Config.getPopularTimeout(),
-        getRedirectedUrl = function()
-            return Config.getUnFavoriteUrl(book_stub.id)
-        end,
-    }
-
-    if http_result.error then
-        logger.warn("Api.unfavoriteBook - HTTP request error: ", http_result.error)
-        return { error = http_result.error }
-    end
-
-    if not http_result.body then
-        logger.warn("Api.unfavoriteBook - No response body")
-        return { error = T("Failed to fetch unfavorite book (no response body).") }
-    end
-
-    local success, data = pcall(json.decode, http_result.body, json.decode.simple)
-    if not success or not data then
-        logger.warn("Api.unfavoriteBook - Failed to decode JSON: ", http_result.body)
-        return { error = T("Failed to parse unfavorite book response.") }
-    end
+    local data, err = _authenticatedJsonGet(
+        Config.getUnFavoriteUrl(book_stub.id), user_id, user_key,
+        Config.getPopularTimeout(),
+        function() return Config.getUnFavoriteUrl(book_stub.id) end,
+        "unfavoriteBook")
+    if not data then return { error = err } end
 
     if data.success ~= 1 then
-        logger.warn("Api.unfavoriteBook - API error: ", http_result.body)
         return { error = data.message or T("API returned an error for unfavorite book.") }
     end
-
     return { success = true }
 end
 
 function Api.getDownloadQuotaStatus(user_id, user_key)
-    local url = Config.getDownloadQuotaUrl()
-    if not url then
-        logger.warn("Api.getDownloadQuotaStatus - Base URL not configured")
-        return { error = T("Z-library server URL not configured.") }
-    end
+    local data, err = _authenticatedJsonGet(
+        Config.getDownloadQuotaUrl(), user_id, user_key,
+        Config.getPopularTimeout(), Config.getDownloadQuotaUrl,
+        "getDownloadQuotaStatus")
+    if not data then return { error = err } end
 
-    local headers = {
-        ['Content-Type'] = 'application/x-www-form-urlencoded',
-        ["User-Agent"] = Config.USER_AGENT,
-    }
-    if user_id and user_key then
-        headers["Cookie"] = string.format("remix_userid=%s; remix_userkey=%s", user_id, user_key)
-    end
-
-    local http_result = Api.makeHttpRequest{
-        url = url,
-        method = "GET",
-        headers = headers,
-        timeout = Config.getPopularTimeout(),
-        getRedirectedUrl = Config.getDownloadQuotaUrl,
-    }
-
-    if http_result.error then
-        logger.warn("Api.getDownloadQuotaStatus - HTTP request error: ", http_result.error)
-        return { error = http_result.error }
-    end
-
-    if not http_result.body then
-        logger.warn("Api.getDownloadQuotaStatus - No response body")
-        return { error = T("Failed to fetch download quota status (no response body).") }
-    end
-
-    local success, data = pcall(json.decode, http_result.body, json.decode.simple)
-    if not success or not data then
-        logger.warn("Api.getDownloadQuotaStatus - Failed to decode JSON: ", http_result.body)
-        return { error = T("Failed to parse download quota status response.") }
-    end
-
-    if not (data.success == 1 and type(data.user) == "table" and data.user.downloads_today ~= nil )then
-        logger.warn("Api.getDownloadQuotaStatus - API error: ", http_result.body)
+    if not (data.success == 1 and type(data.user) == "table" and data.user.downloads_today ~= nil) then
         return { error = data.message or T("API returned an error for download quota status.") }
     end
 
-    return { quota_status = {today = data.user.downloads_today, limit = data.user.downloads_limit}}
+    return { quota_status = { today = data.user.downloads_today, limit = data.user.downloads_limit } }
 end
 
 function Api.getFavoriteBookIds(user_id, user_key)
-    local url = Config.getFavoriteBookIdsUrl()
-    if not url then
-        logger.warn("Api.getFavoriteBookIds - Base URL not configured")
-        return { error = T("Z-library server URL not configured.") }
-    end
+    local data, err = _authenticatedJsonGet(
+        Config.getFavoriteBookIdsUrl(), user_id, user_key,
+        Config.getPopularTimeout(), Config.getFavoriteBookIdsUrl,
+        "getFavoriteBookIds")
+    if not data then return { error = err } end
 
-    local headers = {
-        ['Content-Type'] = 'application/x-www-form-urlencoded',
-        ["User-Agent"] = Config.USER_AGENT,
-    }
-    if user_id and user_key then
-        headers["Cookie"] = string.format("remix_userid=%s; remix_userkey=%s", user_id, user_key)
-    end
-
-    local http_result = Api.makeHttpRequest{
-        url = url,
-        method = "GET",
-        headers = headers,
-        timeout = Config.getPopularTimeout(),
-        getRedirectedUrl = Config.getFavoriteBookIdsUrl,
-    }
-
-    if http_result.error then
-        logger.warn("Api.getFavoriteBookIds - HTTP request error: ", http_result.error)
-        return { error = http_result.error }
-    end
-
-    if not http_result.body then
-        logger.warn("Api.getFavoriteBookIds - No response body")
-        return { error = T("Failed to fetch favorite-book IDs (no response body).") }
-    end
-
-    local success, data = pcall(json.decode, http_result.body, json.decode.simple)
-    if not success or not data then
-        logger.warn("Api.getFavoriteBookIds - Failed to decode JSON: ", http_result.body)
-        return { error = T("Failed to parse favorite-book IDs.") }
-    end
-    
     if not (data.success == 1 and data.books) then
-        logger.warn("Api.getFavoriteBookIds - API error: ", http_result.body)
         return { error = data.message or T("API returned an error for favorite-book IDs.") }
     end
-    
     return { books = data.books }
 end
 
 function Api.favoriteBook(user_id, user_key, book_stub)
-    local url = Config.getFavoriteUrl(book_stub.id)
-    if not url then
-        logger.warn("Api.favoriteBook - Base URL not configured")
-        return { error = T("Z-library server URL not configured.") }
-    end
-
-    local headers = {
-        ['Content-Type'] = 'application/x-www-form-urlencoded',
-        ["User-Agent"] = Config.USER_AGENT,
-    }
-    if user_id and user_key then
-        headers["Cookie"] = string.format("remix_userid=%s; remix_userkey=%s", user_id, user_key)
-    end
-
-    local http_result = Api.makeHttpRequest{
-        url = url,
-        method = "GET",
-        headers = headers,
-        timeout = Config.getPopularTimeout(),
-        getRedirectedUrl = function()
-            return Config.getFavoriteUrl(book_stub.id)
-        end,
-    }
-
-    if http_result.error then
-        logger.warn("Api.favoriteBook - HTTP request error: ", http_result.error)
-        return { error = http_result.error }
-    end
-
-    if not http_result.body then
-        logger.warn("Api.favoriteBook - No response body")
-        return { error = T("Failed to fetch favorite book (no response body).") }
-    end
-
-    local success, data = pcall(json.decode, http_result.body, json.decode.simple)
-    if not success or not data then
-        logger.warn("Api.favoriteBook - Failed to decode JSON: ", http_result.body)
-        return { error = T("Failed to parse favorite book response.") }
-    end
+    local data, err = _authenticatedJsonGet(
+        Config.getFavoriteUrl(book_stub.id), user_id, user_key,
+        Config.getPopularTimeout(),
+        function() return Config.getFavoriteUrl(book_stub.id) end,
+        "favoriteBook")
+    if not data then return { error = err } end
 
     if data.success ~= 1 then
-        logger.warn("Api.favoriteBook - API error: ", http_result.body)
         return { error = data.message or T("API returned an error for favorite book.") }
     end
-
     return { success = true }
 end
 

--- a/zlibrary/async_helper.lua
+++ b/zlibrary/async_helper.lua
@@ -1,3 +1,17 @@
+--[[--
+Deferred-synchronous task executor for the Z-library plugin.
+
+IMPORTANT: This is NOT truly asynchronous. The task function runs to completion
+in a single coroutine.resume() call, blocking the UI thread during execution.
+The only "async" aspect is that UIManager:nextTick defers the START of execution,
+allowing the loading message to render before the blocking task begins.
+
+Flow: show loading → nextTick → resume coroutine (BLOCKS) → close loading → callback
+
+If a task needs to yield control (e.g. prefetchCoversSync), it must explicitly
+call coroutine.yield() and the resume_handler will re-schedule via nextTick.
+--]]--
+
 local UIManager = require("ui/uimanager")
 local coroutine = require("coroutine")
 local logger = require("logger")

--- a/zlibrary/cache.lua
+++ b/zlibrary/cache.lua
@@ -131,4 +131,66 @@ function Cache:clear()
     end
 end
 
+function Cache.getCoversDir()
+    return DataStorage:getDataDir() .. "/cache/zlibrary/covers"
+end
+
+function Cache.getCoverPath(book_hash)
+    if not book_hash or book_hash == "" then return nil end
+    return Cache.getCoversDir() .. "/" .. book_hash .. ".jpg"
+end
+
+function Cache.ensureCoversDir()
+    local dir = Cache.getCoversDir()
+    if not util.directoryExists(dir) then
+        util.makePath(dir)
+        if not util.directoryExists(dir) then
+            -- mkdir -p fallback for Windows and Unix, though mostly Unix in KOReader
+            if Device and Device:isDesktop() and package.config:sub(1,1) == '\\' then
+                os.execute(string.format('mkdir "%s"', dir:gsub("/", "\\")))
+            else
+                os.execute(string.format('mkdir -p "%s"', dir))
+            end
+        end
+    end
+end
+
+--- Elimina covers con más de max_age_days días de antigüedad.
+--- Diseñada para ejecutarse al iniciar el plugin, de forma silenciosa.
+--- @param max_age_days number Días máximos de antigüedad (default: 7)
+function Cache.cleanOldCovers(max_age_days)
+    local lfs = require("libs/libkoreader-lfs")
+    local dir = Cache.getCoversDir()
+
+    max_age_days = max_age_days or 7
+    local max_age_seconds = max_age_days * 86400
+    local now = os.time()
+    local removed = 0
+
+    local ok, err = pcall(function()
+        if not util.directoryExists(dir) then return end
+
+        for filename in lfs.dir(dir) do
+            if filename ~= "." and filename ~= ".." then
+                local filepath = dir .. "/" .. filename
+                local attr = lfs.attributes(filepath)
+                if attr and attr.mode == "file" and attr.modification then
+                    local age = now - attr.modification
+                    if age > max_age_seconds then
+                        os.remove(filepath)
+                        removed = removed + 1
+                    end
+                end
+            end
+        end
+    end)
+
+    if not ok then
+        local logger = require("logger")
+        logger.warn("Cache.cleanOldCovers error:", tostring(err))
+    end
+
+    return removed
+end
+
 return Cache

--- a/zlibrary/cache.lua
+++ b/zlibrary/cache.lua
@@ -50,7 +50,7 @@ function Cache:_ensureInit()
         if not util.directoryExists(dir) then
             util.makePath(dir)
             if not util.directoryExists(dir) then
-                os.execute(string.format('"mkdir -p "%s"', dir))
+                os.execute(string.format('mkdir -p "%s"', dir))
             end
         end
     end

--- a/zlibrary/config.lua
+++ b/zlibrary/config.lua
@@ -151,19 +151,22 @@ Config.SEED_URLS = { -- List of known Z-library base URLs extracted from the And
     "https://z-lib.gl/"
 }
 
+-- Singleton lazy instance to avoid recreating Cache (MD5 + LuaSettings open) on every call
+local _config_runtime_cache
+local function _getConfigRuntimeCache()
+    if not _config_runtime_cache then
+        _config_runtime_cache = Cache:new{ name = "_runtime_cache" }
+    end
+    return _config_runtime_cache
+end
+
 function Config.getCacheRealUrl()
-    local runtime_cache = Cache:new{
-        name = "_runtime_cache"
-    }
-    local api_real_url = runtime_cache:get("api_real_url", 600)
+    local api_real_url = _getConfigRuntimeCache():get("api_real_url", 600)
     return api_real_url and api_real_url[1]
 end
 
 function Config.clearCacheRealUrl()
-    local runtime_cache = Cache:new{
-        name = "_runtime_cache"
-    }
-    return runtime_cache:remove("api_real_url")
+    return _getConfigRuntimeCache():remove("api_real_url")
 end
 
 function Config.setCacheRealUrl(original_url, real_url)
@@ -180,10 +183,7 @@ function Config.setCacheRealUrl(original_url, real_url)
         real_url = string.sub(real_url, 1, -2)
     end
     
-    local runtime_cache = Cache:new{
-        name = "_runtime_cache"
-    }
-    return runtime_cache:insert("api_real_url", {real_url})
+    return _getConfigRuntimeCache():insert("api_real_url", {real_url})
 end
 
 function Config.getBaseUrl(is_original)
@@ -224,7 +224,7 @@ function Config.getLoginUrl()
     return base .. "/eapi/user/login"
 end
 
-function Config.getSearchUrl(query)
+function Config.getSearchUrl()
     local base = Config.getBaseUrl()
     if not base then return nil end
     return base .. "/eapi/book/search"

--- a/zlibrary/dialog_manager.lua
+++ b/zlibrary/dialog_manager.lua
@@ -152,6 +152,10 @@ end
 
 
 function DialogManager:trackDialog(dialog)
+    -- Avoid tracking the same dialog instance twice
+    for _, d in ipairs(self._open_dialogs) do
+        if d == dialog then return dialog end
+    end
     table.insert(self._open_dialogs, dialog)
     return dialog
 end

--- a/zlibrary/menu.lua
+++ b/zlibrary/menu.lua
@@ -6,6 +6,9 @@ local Geom = require("ui/geometry")
 local logger = require("logger")
 local Cache = require("zlibrary.cache")
 local util = require("util")
+local ImageWidget = require("ui/widget/imagewidget")
+local CenterContainer = require("ui/widget/container/centercontainer")
+local WidgetContainer = require("ui/widget/container/widgetcontainer")
 
 local M = Menu:extend{}
 
@@ -97,7 +100,6 @@ function M:getItemShortCutIcon(dimen, key, style)
 
     if not cover_path then
         -- No debería llegar aquí, pero por seguridad
-        local WidgetContainer = require("ui/widget/container/widgetcontainer")
         return WidgetContainer:new{
             dimen = Geom:new{ w = dimen.w, h = dimen.h },
         }
@@ -112,9 +114,6 @@ function M:getItemShortCutIcon(dimen, key, style)
 
     -- Cargar imagen con pcall para evitar crashes
     local load_ok, widget = pcall(function()
-        local ImageWidget = require("ui/widget/imagewidget")
-        local CenterContainer = require("ui/widget/container/centercontainer")
-
         local img = ImageWidget:new{
             file = cover_path,
             width = cover_w,
@@ -137,7 +136,6 @@ function M:getItemShortCutIcon(dimen, key, style)
     pcall(os.remove, cover_path)
 
     -- Retornar widget vacío seguro (con dimensiones correctas)
-    local WidgetContainer = require("ui/widget/container/widgetcontainer")
     return WidgetContainer:new{
         dimen = Geom:new{ w = dimen.w, h = dimen.h },
     }

--- a/zlibrary/menu.lua
+++ b/zlibrary/menu.lua
@@ -1,13 +1,146 @@
 local Menu = require("ui/widget/menu")
+local Device = require("device")
+local Screen = Device.screen
+local Size = require("ui/size")
+local Geom = require("ui/geometry")
+local logger = require("logger")
+local Cache = require("zlibrary.cache")
+local util = require("util")
 
-local M = Menu:extend{
-}
+local M = Menu:extend{}
+
 -- fix no_title = true koreader crash
 function M:mergeTitleBarIntoLayout()
     if self.no_title then
         return
     end
-   Menu.mergeTitleBarIntoLayout(self)
+    Menu.mergeTitleBarIntoLayout(self)
+end
+
+--- Verifica si un cover existe en caché y es válido.
+--- @param hash string El hash del libro
+--- @return string|nil Ruta al cover si existe, nil si no
+local function _getCachedCoverPath(hash)
+    if not hash or hash == "" then return nil end
+    local cover_path = Cache.getCoverPath(hash)
+    if not cover_path then return nil end
+    if not util.fileExists(cover_path) then return nil end
+    return cover_path
+end
+
+--- Override updateItems para inyectar covers SOLO si existen en caché.
+--- Nunca inyecta shortcuts para covers que no estén descargados.
+function M:updateItems(select_number, no_recalculate_dimen)
+    local ok, err = pcall(function()
+        -- Solo procesar si hay item_table y no usa items_max_lines
+        if not self.item_table or self.items_max_lines then
+            Menu.updateItems(self, select_number, no_recalculate_dimen)
+            return
+        end
+
+        -- Detectar items visibles que tienen cover EN CACHÉ
+        local perpage = self.perpage or 14
+        local idx_offset = (self.page - 1) * perpage
+        local cover_shortcuts = {}
+        local has_any_cover = false
+
+        for idx = 1, perpage do
+            local item = self.item_table[idx_offset + idx]
+            if item and type(item.shortcut) == "string" and item.shortcut:sub(1, 6) == "cover:" then
+                local hash = item.shortcut:sub(7)
+                local cached_path = _getCachedCoverPath(hash)
+                if cached_path then
+                    -- Cover existe en caché: inyectar shortcut
+                    cover_shortcuts[idx] = item.shortcut
+                    has_any_cover = true
+                end
+                -- Si NO existe en caché: no inyectar shortcut (se muestra solo texto)
+            end
+        end
+
+        if has_any_cover then
+            -- Guardar estado original
+            local orig_enable = self.is_enable_shortcut
+            local orig_shortcuts = self.item_shortcuts
+
+            self.is_enable_shortcut = true
+            self.item_shortcuts = cover_shortcuts
+
+            Menu.updateItems(self, select_number, no_recalculate_dimen)
+
+            -- Restaurar estado
+            self.item_shortcuts = orig_shortcuts
+            self.is_enable_shortcut = orig_enable
+        else
+            -- Ningún cover en caché: renderizar sin covers
+            Menu.updateItems(self, select_number, no_recalculate_dimen)
+        end
+    end)
+
+    if not ok then
+        logger.err("zlibrary.menu:updateItems error:", tostring(err))
+        -- Fallback: renderizar sin covers
+        self.is_enable_shortcut = false
+        pcall(Menu.updateItems, self, select_number, no_recalculate_dimen)
+    end
+end
+
+--- Override getItemShortCutIcon para renderizar portadas.
+--- Solo se llama para items que tienen cover confirmado en caché.
+function M:getItemShortCutIcon(dimen, key, style)
+    if type(key) ~= "string" or key:sub(1, 6) ~= "cover:" then
+        return Menu.getItemShortCutIcon(self, dimen, key, style)
+    end
+
+    local hash = key:sub(7)
+    local cover_path = _getCachedCoverPath(hash)
+
+    if not cover_path then
+        -- No debería llegar aquí, pero por seguridad
+        local WidgetContainer = require("ui/widget/container/widgetcontainer")
+        return WidgetContainer:new{
+            dimen = Geom:new{ w = dimen.w, h = dimen.h },
+        }
+    end
+
+    -- Dimensiones rectangulares: ratio ~2:3 (portada de libro estándar)
+    local cover_h = dimen.h
+    local cover_w = math.floor(cover_h * 2 / 3)
+    if cover_w > dimen.w then
+        cover_w = dimen.w
+    end
+
+    -- Cargar imagen con pcall para evitar crashes
+    local load_ok, widget = pcall(function()
+        local ImageWidget = require("ui/widget/imagewidget")
+        local CenterContainer = require("ui/widget/container/centercontainer")
+
+        local img = ImageWidget:new{
+            file = cover_path,
+            width = cover_w,
+            height = cover_h,
+            scale_factor = 0, -- auto-escala preservando aspecto
+        }
+
+        return CenterContainer:new{
+            dimen = Geom:new{ w = dimen.w, h = dimen.h },
+            img,
+        }
+    end)
+
+    if load_ok and widget then
+        return widget
+    end
+
+    -- Si falla la carga de imagen, eliminar el archivo corrupto
+    logger.err("zlibrary.menu: ImageWidget failed:", tostring(widget))
+    pcall(os.remove, cover_path)
+
+    -- Retornar widget vacío seguro (con dimensiones correctas)
+    local WidgetContainer = require("ui/widget/container/widgetcontainer")
+    return WidgetContainer:new{
+        dimen = Geom:new{ w = dimen.w, h = dimen.h },
+    }
 end
 
 return M

--- a/zlibrary/multisearch_dialog.lua
+++ b/zlibrary/multisearch_dialog.lua
@@ -303,6 +303,7 @@ function SearchDialog:createMenuContainer(books, height)
             width = self.width - Screen:scaleBySize(6),
             height = height,
             item_table = menu_items,
+            items_per_page = 5, -- Altura más amplia para permitir renderizar portadas
             is_popout = false,
             no_title = true,
             show_captions = true,

--- a/zlibrary/multisearch_dialog.lua
+++ b/zlibrary/multisearch_dialog.lua
@@ -247,6 +247,7 @@ function SearchDialog:_getMenuItems(books)
             book_index = i,
             text = menu_text,
             mandatory = mandatory_text,
+            shortcut = book.hash and ("cover:" .. book.hash) or nil,
         })
     end
     return menu_items
@@ -267,7 +268,7 @@ function SearchDialog:reloadFromBookData(books, skip_cache, select_number, no_re
     local old_height = self.menu_container.height
     self.menu_container = self:createMenuContainer(books, old_height)
 
-    Menu.updateItems(self.menu_container, select_number, no_recalculate_dimen)
+    self.menu_container:updateItems(select_number, no_recalculate_dimen)
 
     if not skip_cache then
         local cache_key = self:getActiveItemCacheKey()
@@ -446,8 +447,13 @@ function SearchDialog:setToggleTitle(position, title)
     if position > toggle_items_count or position < 1 then
         return
     end
-    self.toggle_items[1].text = title or ""
-    self:init()
+    self.toggle_items[position].text = title or ""
+
+    -- Update the toggle switch text directly instead of rebuilding the entire widget
+    if self.toggle_switch and self.toggle_switch.toggle then
+        self.toggle_switch.toggle[position] = title or ""
+        self.toggle_switch:update()
+    end
     UIManager:setDirty("all", "ui")
 end
 

--- a/zlibrary/ui.lua
+++ b/zlibrary/ui.lua
@@ -11,6 +11,7 @@ local logger = require("logger")
 local Config = require("zlibrary.config")
 local Api = require("zlibrary.api")
 local AsyncHelper = require("zlibrary.async_helper")
+local coroutine = require("coroutine")
 
 local Ui = {}
 
@@ -732,22 +733,6 @@ local function _showBooksMenu(ui_self, options, plugin_self)
     _showAndTrackDialog(menu)
 end
 
-function Ui.showRecommendedBooksMenu(ui_self, books, plugin_self)
-    _showBooksMenu(ui_self, {
-        title = T("Z-library Recommended Books"),
-        books = books,
-        log_context = "recommended books",
-    }, plugin_self)
-end
-
-function Ui.showMostPopularBooksMenu(ui_self, books, plugin_self)
-    _showBooksMenu(ui_self, {
-        title = T("Z-library Most Popular Books"),
-        books = books,
-        log_context = "most popular books",
-    }, plugin_self)
-end
-
 function Ui.showSimilarBooksMenu(ui_self, books, plugin_self, source_title)
     _showBooksMenu(ui_self, {
         title = T("Z-library Similar Books"),
@@ -757,43 +742,7 @@ function Ui.showSimilarBooksMenu(ui_self, books, plugin_self, source_title)
     }, plugin_self)
 end
 
-function Ui.confirmShowRecommendedBooks(ok_callback)
-    if _plugin_instance and _plugin_instance.dialog_manager then
-        _plugin_instance.dialog_manager:showConfirmDialog({
-            text = T("Fetch most recommended book from Z-library?"),
-            ok_text = T("OK"),
-            cancel_text = T("Cancel"),
-            ok_callback = ok_callback,
-        })
-    else
-        local dialog = ConfirmBox:new{
-            text = T("Fetch most recommended book from Z-library?"),
-            ok_text = T("OK"),
-            cancel_text = T("Cancel"),
-            ok_callback = ok_callback,
-        }
-        UIManager:show(dialog)
-    end
-end
 
-function Ui.confirmShowMostPopularBooks(ok_callback)
-    if _plugin_instance and _plugin_instance.dialog_manager then
-        _plugin_instance.dialog_manager:showConfirmDialog({
-            text = T("Fetch most popular books from Z-library?"),
-            ok_text = T("OK"),
-            cancel_text = T("Cancel"),
-            ok_callback = ok_callback,
-        })
-    else
-        local dialog = ConfirmBox:new{
-            text = T("Fetch most popular books from Z-library?"),
-            ok_text = T("OK"),
-            cancel_text = T("Cancel"),
-            ok_callback = ok_callback,
-        }
-        UIManager:show(dialog)
-    end
-end
 
 function Ui.createSingleBookMenu(ui_self, title, menu_items)
     local menu = Menu:new{
@@ -1186,6 +1135,11 @@ function Ui.prefetchCoversSync(books, max_covers)
                     -- Limpiar archivo parcial si existe
                     pcall(os.remove, target_path)
                     downloaded = downloaded + 1 -- contar como intento para no quedarse atrapado
+                end
+                -- Yield control to UIManager between downloads to prevent
+                -- long UI freezes on e-ink devices (works with AsyncHelper coroutines)
+                if coroutine.running() then
+                    coroutine.yield()
                 end
             end
         end

--- a/zlibrary/ui.lua
+++ b/zlibrary/ui.lua
@@ -435,6 +435,7 @@ function Ui.createBookMenuItem(book_data, parent_zlibrary_instance)
 
     return {
         text = combined_text,
+        shortcut = book_data.hash and ("cover:" .. book_data.hash) or nil,
         callback = function()
             if book_data.needs_detail_fetch then
                 parent_zlibrary_instance:onSelectSearchBook(book_data)
@@ -454,7 +455,7 @@ function Ui.createSearchResultsMenu(parent_ui_ref, query_string, initial_menu_it
         subtitle = string.format("%s: %s", T("Sort by"), search_order_name),
         item_table = initial_menu_items,
         parent = parent_ui_ref,
-        items_per_page = 10,
+        items_per_page = 5, -- Reducido de 10 a 5 para forzar mayor altura (ver bien las portadas)
         show_captions = true,
         onGotoPage = on_goto_page_handler,
         is_popout = false,
@@ -701,11 +702,11 @@ local function _showBooksMenu(ui_self, options, plugin_self)
     local subtitle = options.subtitle
 
     local menu_items = {}
-    local menu_item
     for _, book in ipairs(books) do
-        menu_item = Ui.createBookMenuItem(book, plugin_self)
+        local menu_item = Ui.createBookMenuItem(book, plugin_self)
         table.insert(menu_items, {
             text = menu_item.text,
+            shortcut = menu_item.shortcut,
             callback = function()
                 plugin_self:onSelectRecommendedBook(book)
             end,
@@ -720,7 +721,7 @@ local function _showBooksMenu(ui_self, options, plugin_self)
         title = title,
         subtitle = subtitle,
         item_table = menu_items,
-        items_per_page = 10,
+        items_per_page = 5,
         show_captions = true,
         parent = ui_self.document_menu_parent_holder,
         is_popout = false,
@@ -1140,6 +1141,56 @@ function Ui.showAllTimeoutConfigDialog(parent_ui)
         show_captions = true,
     }
     _showAndTrackDialog(main_menu)
+end
+
+--- Descarga portadas de forma síncrona (bloqueante).
+--- Diseñada para ejecutarse DENTRO de un task de AsyncHelper,
+--- de modo que el mensaje de "cargando" se muestre mientras ocurre.
+--- IMPORTANTE: Solo descarga las primeras MAX_COVERS portadas para evitar
+--- bloquear el dispositivo durante demasiado tiempo.
+--- @param books table Lista de book_data con campos .cover y .hash
+--- @param max_covers number Máximo de portadas a descargar (default: 50)
+function Ui.prefetchCoversSync(books, max_covers)
+    if type(books) ~= "table" then return end
+
+    local Cache = require("zlibrary.cache")
+    local util_mod = require("util")
+    local Api = require("zlibrary.api")
+    local logger = require("logger")
+
+    max_covers = max_covers or 50
+    local downloaded = 0
+
+    local ok_dir, _ = pcall(Cache.ensureCoversDir)
+    if not ok_dir then
+        logger.err("prefetchCoversSync: failed to create covers directory")
+        return
+    end
+
+    for _, book in ipairs(books) do
+        if downloaded >= max_covers then break end
+
+        if book.cover and book.cover ~= "" and book.hash then
+            local target_path = Cache.getCoverPath(book.hash)
+
+            -- Si ya existe en caché, no cuenta como descarga nueva
+            if util_mod.fileExists(target_path) then
+                -- ya está, no hacer nada
+            else
+                local ok, result = pcall(Api.downloadBookCover, book.cover, target_path)
+                if ok and result and result.success then
+                    logger.dbg("prefetchCoversSync: OK", book.hash)
+                    downloaded = downloaded + 1
+                else
+                    logger.warn("prefetchCoversSync: FAIL", book.hash, ok and (result and result.error or "unknown") or tostring(result))
+                    -- Limpiar archivo parcial si existe
+                    pcall(os.remove, target_path)
+                    downloaded = downloaded + 1 -- contar como intento para no quedarse atrapado
+                end
+            end
+        end
+    end
+    logger.info(string.format("prefetchCoversSync: completed (%d downloads)", downloaded))
 end
 
 return Ui


### PR DESCRIPTION
## Summary

Add book cover thumbnail display across all book listing views — search results, recommended, most popular, downloaded books, and favorites. Covers are pre-downloaded synchronously during the API fetch phase (inside `AsyncHelper` tasks) so they are ready to render immediately when the menu appears, avoiding UI blocking on e-ink devices.

## Motivation

Currently, book listings only display text (title, author, format). Adding cover thumbnails makes it significantly easier to identify books at a glance, creating a much richer browsing experience — especially on e-ink readers where visual cues reduce the need for extra taps.

## Changes

### `zlibrary/cache.lua` — Cover Caching Infrastructure
- `Cache.getCoversDir()` — Returns the covers cache directory path
- `Cache.getCoverPath(hash)` — Returns the expected file path for a book cover by its hash
- `Cache.ensureCoversDir()` — Creates the covers directory with fallback for different OS environments
- `Cache.cleanOldCovers(max_age_days)` — Removes cover files older than N days (default: 7)

### `zlibrary/menu.lua` — Cover Rendering Engine
- `_getCachedCoverPath(hash)` — Helper to verify a cover exists in cache before rendering
- `M:updateItems()` — Override that detects items with `cover:HASH` shortcuts, enables rendering only for confirmed cached covers
- `M:getItemShortCutIcon()` — Renders `ImageWidget` thumbnails at 2:3 aspect ratio with `pcall` protection

### `zlibrary/ui.lua` — Cover Pre-download & Menu Integration
- `Ui.prefetchCoversSync(books, max_covers)` — Synchronous bulk cover downloader (runs inside async tasks)
- `Ui.createBookMenuItem()` — Now injects `shortcut = "cover:" .. hash`
- Reduced `items_per_page` from 10 to 5 for taller rows that properly display covers

### `zlibrary/multisearch_dialog.lua` — Layout Adjustment
- Set `items_per_page = 5` for consistent cover display height

### `main.lua` — Pre-download Hook Integration
- Added `prefetch_task` hook in `_requestDispatcher()` for cover pre-download
- Integrated cover pre-download in all book list fetch operations
- Silent cleanup of old covers on plugin startup

### `_meta.lua` — Version Bump
- `1.0.29` → `1.0.30`

## Safety & E-ink Considerations

- **No UI blocking**: All downloads happen inside `AsyncHelper` tasks
- **Fail-safe rendering**: Triple `pcall` protection in updateItems, getItemShortCutIcon, and image loading
- **Corrupted file cleanup**: Auto-deletion of files that fail to load
- **Bounded downloads**: Maximum 50 covers per batch
- **Auto-cleanup**: Covers older than 7 days removed on startup
- **Cache-only rendering**: Never triggers downloads during rendering