### PR TITLE
Merge "Set base URL" and "Auto-discover base URL" menus and add interactive discover widget

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -62,7 +62,7 @@ function Zlibrary:onZlibrarySearch()
     return true
 end
 
-function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive)
+function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
     if NetworkMgr:willRerunWhenOnline(function()
         self:autoDiscoverAndSetBaseUrl(is_interactive)
     end) then
@@ -70,7 +70,9 @@ function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive)
     end
 
     logger.info("Zlibrary:autoDiscoverAndSetBaseUrl - START")
-    
+
+    local domains_cache = Cache:new{ name = "_domains_cache" }
+
     local updateDomainsCache = function()
         logger.info("Zlibrary:autoDiscoverAndSetBaseUrl - Domains not in cache, fetching from remote...")
         local response = Api.fetchDynamicDomains()
@@ -82,8 +84,7 @@ function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive)
                 end
             end
             if #flat_domains > 0 then
-                logger.info(string.format("Zlibrary:autoDiscoverAndSetBaseUrl - Successfully extracted %d domains, updating cache", #flat_domains))
-                local domains_cache = Cache:new{ name = "_domains_cache" }
+                logger.info(string.format("Zlibrary:autoDiscoverAndSetBaseUrl - Successfully extracted %d domains", #flat_domains))
                 domains_cache:insert("domains", flat_domains) 
             else
                 logger.warn("Zlibrary:autoDiscoverAndSetBaseUrl - Remote fetch succeeded, but no valid domains were extracted")
@@ -91,128 +92,149 @@ function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive)
         end
     end
 
-    if not Cache:new{ name = "_domains_cache" }:get("domains", 172800) then
-        local loading_msg = Ui.showLoadingMessage(T("Searching for working Z-library server..."))
-        AsyncHelper.run(updateDomainsCache, nil, nil, loading_msg)
-    end
+    local executeDiscovery = function()
+        local seed_urls = Config.getSeedUrls()
+        local progress_callback
 
-    local seed_urls = Config.getSeedUrls()
-    local progress_callback
-
-    local task = function()
-        return Api.findWorkingBaseUrl(seed_urls, progress_callback)
-    end                    
-    local on_success = function(result)
-        if result.success and result.url then
-            local success, err_msg = Config.setAndValidateBaseUrl(result.url)
-            if success then
-                logger.info("Zlibrary:autoDiscoverAndSetBaseUrl - Successfully set base URL to: " .. result.url)
-                Ui.showInfoMessage(T("Successfully found and set base URL to: ") .. result.url)
-            else
-                logger.warn("Zlibrary:autoDiscoverAndSetBaseUrl - Failed to validate discovered URL: " .. (err_msg or "Unknown error"))
-            end    
-        else
-            logger.warn("Zlibrary:autoDiscoverAndSetBaseUrl - Failed to discover working base URL")            Ui.showErrorMessage(result.error or T("Failed to find a working base URL."))
-        end
-    end                  
-    local on_error = function(err_msg)
-        Ui.showErrorMessage(T("Error during auto-discovery: ") .. tostring(err_msg))
-    end
-
-    if is_interactive ~= true then
-        local loading_msg = Ui.showLoadingMessage(T("Searching for working Z-library server..."))
-        AsyncHelper.run(task, on_success, on_error, loading_msg)
-    else
-        local connection_menu
-        local menu_items = {{
-            text = T("Start"),
-            mandatory = "\u{25B7}",
-            callback = function()
-                local loading_msg = Ui.showLoadingMessage(T("Searching for working Z-library server..."))
-                AsyncHelper.run(task, on_success, on_error, loading_msg)
-            end,
-        }, { text = "---" }}
-        local has_clipboard = Device:hasClipboard()
-
-        for i, seed_item in ipairs(seed_urls) do
-            local raw_url = type(seed_item) == "table" and seed_item.url or tostring(seed_item)
-            local src_str = type(seed_item) == "table" and seed_item.src or "X"
-            local display_url = raw_url:gsub("^https?://", ""):gsub("/$", "")
-            table.insert(menu_items, {
-                text = string.format("[%s] %s", src_str, display_url),
-                mandatory = "\u{23F3} " .. T("Queued"),
-                show_indicator = false,
-                callback = has_clipboard and function()
-                    local c_text = display_url
-                     Device.input.setClipboardText(string.format("https://%s", c_text))
-                     Ui.showInfoMessage(T("Selection copied to clipboard."))
-                end,
-            })
-        end
-        table.insert(menu_items, { text = "---" })
-        table.insert(menu_items, {
-            text = T("Refresh Dynamic Domains"),
-            mandatory = "\u{25B7}",
-            callback = function()
-                updateDomainsCache()
-                if connection_menu then UIManager:close(connection_menu) end
-            end,
-        })
-        table.insert(menu_items, {
-            text = T("Prioritize Custom BaseUrls"),
-            mandatory = "\u{25B7}",
-            callback = function()
-                local cred_file_path = self.plugin_path .. Config.CREDENTIALS_FILENAME
-                Ui.showSimpleMessageDialog("", (string.format(T("Please edit the `seedUrls` list in file `%s` or submit an issue on GitHub."), cred_file_path)))
-            end,
-        })
-        table.insert(menu_items, {
-            text = T("Back"),
-            mandatory = "\u{21A9}",
-            callback = function()
-                if connection_menu then UIManager:close(connection_menu) end
-            end,
-        })
-
-        connection_menu = Ui.showUrlCheckProgress(self, menu_items)
-
-        progress_callback = function(status, check_result)
-            if not (connection_menu and connection_menu.item_table) then return end
-            if type(check_result) ~= "table" then return end
-            local update_item_index = check_result.index + 2
-            local item = connection_menu.item_table[update_item_index]
-            if not item then return end
-
-            if status == "START" then
-                item.mandatory = "\u{27F3} " .. T("Checking")
-                item.bold = true
-            elseif status == "END" then
-                item.bold = false
-                if check_result.success then
-                    item.mandatory = string.format("\u{2714} %dms", check_result.duration or 0)
-                    item.callback = function()
-                        local ok, err_msg = Config.setAndValidateBaseUrl(check_result.url)
-                        if ok then
-                            Ui.showInfoMessage(string.format("%s : %s", T("Set base URL"), tostring(check_result.url)))
-                        else
-                            Ui.showInfoMessage( T("Invalid Base URL.") .. tostring(err_msg))
-                        end
+        local task = function()
+            return Api.findWorkingBaseUrl(seed_urls, progress_callback)
+        end                    
+        
+        local on_success = function(result)
+            if result.success and result.url then
+                local success, err_msg = Config.setAndValidateBaseUrl(result.url)
+                if success then
+                    logger.info("Zlibrary:autoDiscoverAndSetBaseUrl - Successfully set base URL to: " .. result.url)
+                    if is_interactive ~= true and type(retry_callback) == "function" then 
+                        retry_callback() 
+                    else
+                        Ui.showInfoMessage(T("Successfully found and set base URL to: ") .. result.url)
                     end
                 else
-                    item.mandatory = "\u{2718} " .. T("Failed")
-                    item.callback = function()
-                        Ui.showInfoMessage(check_result.error or T("Unknown error"))
+                    logger.warn("Zlibrary:autoDiscoverAndSetBaseUrl - Failed to validate discovered URL: " .. (err_msg or "Unknown error"))
+                end    
+            else
+                logger.warn("Zlibrary:autoDiscoverAndSetBaseUrl - Failed to discover working base URL")
+                Ui.showErrorMessage(result.error or T("Failed to find a working base URL."))
+            end
+        end                  
+        
+        local on_error = function(err_msg)
+            Ui.showErrorMessage(T("Error during auto-discovery: ") .. tostring(err_msg))
+        end
+
+        if is_interactive ~= true then
+            local loading_msg = Ui.showLoadingMessage(T("Searching for working Z-library server..."))
+            AsyncHelper.run(task, on_success, on_error, loading_msg)
+        else
+            local connection_menu
+            local menu_items = {{
+                text = T("Start"),
+                mandatory = "\u{25B7}",
+                callback = function()
+                    local loading_msg = Ui.showLoadingMessage(T("Searching for working Z-library server..."))
+                    AsyncHelper.run(task, on_success, on_error, loading_msg)
+                end,
+            }, { text = "---" }}
+            
+            local item_index_offset = #menu_items
+            local has_clipboard = Device:hasClipboard()
+
+            for i, seed_item in ipairs(seed_urls) do
+                local raw_url = type(seed_item) == "table" and seed_item.url or tostring(seed_item)
+                local src_str = type(seed_item) == "table" and seed_item.src or "X"
+                local display_url = raw_url:gsub("^https?://", ""):gsub("/$", "")
+                table.insert(menu_items, {
+                    text = string.format("[%s] %s", src_str, display_url),
+                    mandatory = "\u{23F3} " .. T("Queued"),
+                    show_indicator = false,
+                    callback = has_clipboard and function()
+                        local c_text = display_url
+                        Device.input.setClipboardText(string.format("https://%s", c_text))
+                        Ui.showInfoMessage(T("Selection copied to clipboard."))
+                    end or nil,
+                })
+            end
+            
+            table.insert(menu_items, { text = "---" })
+            table.insert(menu_items, {
+                text = T("Refresh Dynamic Domains"),
+                mandatory = "\u{25B7}",
+                callback = function()
+                    if connection_menu then UIManager:close(connection_menu) end
+                    local loading_msg = Ui.showLoadingMessage(T("Fetching dynamic domains..."))
+                    AsyncHelper.run(updateDomainsCache, function()
+                        self:autoDiscoverAndSetBaseUrl(true) 
+                    end, on_error, loading_msg)
+                end,
+            })
+            table.insert(menu_items, {
+                text = T("Prioritize Custom BaseUrls"),
+                mandatory = "\u{25B7}",
+                callback = function()
+                    local cred_file_path = self.plugin_path .. Config.CREDENTIALS_FILENAME
+                    Ui.showSimpleMessageDialog("", (string.format(T("Please edit the `seedUrls` list in file `%s` or submit an issue on GitHub."), cred_file_path)))
+                end,
+            })
+            table.insert(menu_items, {
+                text = T("Back"),
+                mandatory = "\u{21A9}",
+                callback = function()
+                    if connection_menu then UIManager:close(connection_menu) end
+                end,
+            })
+
+            connection_menu = Ui.showUrlCheckProgress(self, menu_items)
+
+            progress_callback = function(status, check_result)
+                if not (connection_menu and connection_menu.item_table) then return end
+                if type(check_result) ~= "table" then return end
+                
+                local update_item_index = check_result.index + item_index_offset
+                local item = connection_menu.item_table[update_item_index]
+                if not item then return end
+
+                if status == "START" then
+                    item.mandatory = "\u{27F3} " .. T("Checking")
+                    item.bold = true
+                elseif status == "END" then
+                    item.bold = false
+                    if check_result.success then
+                        item.mandatory = string.format("\u{2714} %dms", check_result.duration or 0)
+                        item.callback = function()
+                            local ok, err_msg = Config.setAndValidateBaseUrl(check_result.url)
+                            if ok then
+                                Ui.showInfoMessage(string.format("%s : %s", T("Set base URL"), tostring(check_result.url)))
+                            else
+                                Ui.showInfoMessage( T("Invalid Base URL.") .. " " .. tostring(err_msg))
+                            end
+                        end
+                    else
+                        item.mandatory = "\u{2718} " .. T("Failed")
+                        item.callback = function()
+                            Ui.showInfoMessage(check_result.error or T("Unknown error"))
+                        end
                     end
                 end
-            end
 
-            UIManager:nextTick(function()
-                connection_menu:switchItemTable(nil, nil, update_item_index)
-                connection_menu:updateItems(nil, true)
-                UIManager:setDirty(connection_menu, "ui")
-                UIManager:forceRePaint()
-            end)
+                UIManager:nextTick(function()
+                    connection_menu:switchItemTable(nil, nil, update_item_index)
+                    connection_menu:updateItems(nil, true)
+                    UIManager:setDirty(connection_menu, "ui")
+                    UIManager:forceRePaint()
+                end)
+            end
         end
+    end
+
+    if domains_cache:get("domains", 172800) then
+        executeDiscovery()
+    else
+        local loading_msg = Ui.showLoadingMessage(T("Fetching dynamic domains..."))
+        AsyncHelper.run(updateDomainsCache, executeDiscovery, function(err)
+            Ui.showErrorMessage(T("Failed to fetch domains: ") .. tostring(err))
+            executeDiscovery()
+        end, loading_msg)
     end
 end
 

--- a/main.lua
+++ b/main.lua
@@ -50,8 +50,6 @@ function Zlibrary:init()
     else
         logger.warn("self.ui or self.ui.menu not initialized in Zlibrary:init")
     end
-
-    self._runtime_cache = Config.getConfigRuntimeCache()
 end
 
 function Zlibrary:onZlibrarySearch()
@@ -64,18 +62,16 @@ function Zlibrary:onZlibrarySearch()
     return true
 end
 
-function Zlibrary:autoDiscoverAndSetBaseUrl()
+function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive)
     if NetworkMgr:willRerunWhenOnline(function()
-        self:autoDiscoverAndSetBaseUrl()
+        self:autoDiscoverAndSetBaseUrl(is_interactive)
     end) then
         return { success = false, error = T("Network not available. Please connect and try again.") }
     end
 
     logger.info("Zlibrary:autoDiscoverAndSetBaseUrl - START")
-
-    local domains_cache = Cache:new{ name = "_domains_cache" }
-    local domains = domains_cache:get("domains", 86400)
-    if not domains then
+    
+    local updateDomainsCache = function()
         logger.info("Zlibrary:autoDiscoverAndSetBaseUrl - Domains not in cache, fetching from remote...")
         local response = Api.fetchDynamicDomains()
         if response.success and response.domains and type(response.domains.domains) == "table" then
@@ -87,6 +83,7 @@ function Zlibrary:autoDiscoverAndSetBaseUrl()
             end
             if #flat_domains > 0 then
                 logger.info(string.format("Zlibrary:autoDiscoverAndSetBaseUrl - Successfully extracted %d domains, updating cache", #flat_domains))
+                local domains_cache = Cache:new{ name = "_domains_cache" }
                 domains_cache:insert("domains", flat_domains) 
             else
                 logger.warn("Zlibrary:autoDiscoverAndSetBaseUrl - Remote fetch succeeded, but no valid domains were extracted")
@@ -94,21 +91,129 @@ function Zlibrary:autoDiscoverAndSetBaseUrl()
         end
     end
 
-    local result = Api.findWorkingBaseUrl()
-    
-    if result.success and result.url then
-        local success, err_msg = Config.setAndValidateBaseUrl(result.url)
-        if success then
-            logger.info("Zlibrary:autoDiscoverAndSetBaseUrl - Successfully set base URL to: " .. result.url)
-            return { success = true, url = result.url }
+    if not Cache:new{ name = "_domains_cache" }:get("domains", 172800) then
+        local loading_msg = Ui.showLoadingMessage(T("Searching for working Z-library server..."))
+        AsyncHelper.run(updateDomainsCache, nil, nil, loading_msg)
+    end
+
+    local seed_urls = Config.getSeedUrls()
+    local progress_callback
+
+    local task = function()
+        return Api.findWorkingBaseUrl(seed_urls, progress_callback)
+    end                    
+    local on_success = function(result)
+        if result.success and result.url then
+            local success, err_msg = Config.setAndValidateBaseUrl(result.url)
+            if success then
+                logger.info("Zlibrary:autoDiscoverAndSetBaseUrl - Successfully set base URL to: " .. result.url)
+                Ui.showInfoMessage(T("Successfully found and set base URL to: ") .. result.url)
+            else
+                logger.warn("Zlibrary:autoDiscoverAndSetBaseUrl - Failed to validate discovered URL: " .. (err_msg or "Unknown error"))
+            end    
         else
-            logger.warn("Zlibrary:autoDiscoverAndSetBaseUrl - Failed to validate discovered URL: " .. (err_msg or "Unknown error"))
-            return { success = false, error = err_msg }
+            logger.warn("Zlibrary:autoDiscoverAndSetBaseUrl - Failed to discover working base URL")            Ui.showErrorMessage(result.error or T("Failed to find a working base URL."))
+        end
+    end                  
+    local on_error = function(err_msg)
+        Ui.showErrorMessage(T("Error during auto-discovery: ") .. tostring(err_msg))
+    end
+
+    if is_interactive ~= true then
+        local loading_msg = Ui.showLoadingMessage(T("Searching for working Z-library server..."))
+        AsyncHelper.run(task, on_success, on_error, loading_msg)
+    else
+        local connection_menu
+        local menu_items = {{
+            text = T("Start"),
+            mandatory = "\u{25B7}",
+            callback = function()
+                local loading_msg = Ui.showLoadingMessage(T("Searching for working Z-library server..."))
+                AsyncHelper.run(task, on_success, on_error, loading_msg)
+            end,
+        }, { text = "---" }}
+        local has_clipboard = Device:hasClipboard()
+
+        for i, seed_item in ipairs(seed_urls) do
+            local raw_url = type(seed_item) == "table" and seed_item.url or tostring(seed_item)
+            local src_str = type(seed_item) == "table" and seed_item.src or "X"
+            local display_url = raw_url:gsub("^https?://", ""):gsub("/$", "")
+            table.insert(menu_items, {
+                text = string.format("[%s] %s", src_str, display_url),
+                mandatory = "\u{23F3} " .. T("Queued"),
+                show_indicator = false,
+                callback = has_clipboard and function()
+                    local c_text = display_url
+                     Device.input.setClipboardText(string.format("https://%s", c_text))
+                     Ui.showInfoMessage(T("Selection copied to clipboard."))
+                end,
+            })
+        end
+        table.insert(menu_items, { text = "---" })
+        table.insert(menu_items, {
+            text = T("Refresh Dynamic Domains"),
+            mandatory = "\u{25B7}",
+            callback = function()
+                updateDomainsCache()
+                if connection_menu then UIManager:close(connection_menu) end
+            end,
+        })
+        table.insert(menu_items, {
+            text = T("Prioritize Custom BaseUrls"),
+            mandatory = "\u{25B7}",
+            callback = function()
+                local cred_file_path = self.plugin_path .. Config.CREDENTIALS_FILENAME
+                Ui.showSimpleMessageDialog("", (string.format(T("Please edit the `seedUrls` list in file `%s` or submit an issue on GitHub."), cred_file_path)))
+            end,
+        })
+        table.insert(menu_items, {
+            text = T("Back"),
+            mandatory = "\u{21A9}",
+            callback = function()
+                if connection_menu then UIManager:close(connection_menu) end
+            end,
+        })
+
+        connection_menu = Ui.showUrlCheckProgress(self, menu_items)
+
+        progress_callback = function(status, check_result)
+            if not (connection_menu and connection_menu.item_table) then return end
+            if type(check_result) ~= "table" then return end
+            local update_item_index = check_result.index + 2
+            local item = connection_menu.item_table[update_item_index]
+            if not item then return end
+
+            if status == "START" then
+                item.mandatory = "\u{27F3} " .. T("Checking")
+                item.bold = true
+            elseif status == "END" then
+                item.bold = false
+                if check_result.success then
+                    item.mandatory = string.format("\u{2714} %dms", check_result.duration or 0)
+                    item.callback = function()
+                        local ok, err_msg = Config.setAndValidateBaseUrl(check_result.url)
+                        if ok then
+                            Ui.showInfoMessage(string.format("%s : %s", T("Set base URL"), tostring(check_result.url)))
+                        else
+                            Ui.showInfoMessage( T("Invalid Base URL.") .. tostring(err_msg))
+                        end
+                    end
+                else
+                    item.mandatory = "\u{2718} " .. T("Failed")
+                    item.callback = function()
+                        Ui.showInfoMessage(check_result.error or T("Unknown error"))
+                    end
+                end
+            end
+
+            UIManager:nextTick(function()
+                connection_menu:switchItemTable(nil, nil, update_item_index)
+                connection_menu:updateItems(nil, true)
+                UIManager:setDirty(connection_menu, "ui")
+                UIManager:forceRePaint()
+            end)
         end
     end
-    
-    logger.warn("Zlibrary:autoDiscoverAndSetBaseUrl - Failed to discover working base URL")
-    return { success = false, error = T("Failed to discover a working base URL") }
 end
 
 function Zlibrary:addToMainMenu(menu_items)
@@ -146,27 +251,7 @@ function Zlibrary:addToMainMenu(menu_items)
                             text = T("Auto-discover base URL"),
                             keep_menu_open = true,
                             callback = function()
-                                local loading_msg = Ui.showLoadingMessage(T("Searching for working Z-library server..."))
-                                
-                                local task = function()
-                                    return self:autoDiscoverAndSetBaseUrl()
-                                end
-                                
-                                local on_success = function(result)
-                                    Ui.closeMessage(loading_msg)
-                                    if result.success then
-                                        Ui.showInfoMessage(T("Successfully found and set base URL to: ") .. result.url)
-                                    else
-                                        Ui.showErrorMessage(result.error or T("Failed to find a working base URL."))
-                                    end
-                                end
-                                
-                                local on_error = function(err_msg)
-                                    Ui.closeMessage(loading_msg)
-                                    Ui.showErrorMessage(T("Error during auto-discovery: ") .. tostring(err_msg))
-                                end
-                                
-                                AsyncHelper.run(task, on_success, on_error)
+                                UIManager:nextTick(function() self:autoDiscoverAndSetBaseUrl(true) end)
                             end,
                             separator = true,
                         },
@@ -275,7 +360,7 @@ function Zlibrary:addToMainMenu(menu_items)
                                         text = T("Clear runtime cache"),
                                         keep_menu_open = true,
                                         callback = function()
-                                            self._runtime_cache:clear()
+                                            Config.getConfigRuntimeCache():clear()
                                             Cache:new{ name = "_domains_cache" }:clear()
                                             Ui.showInfoMessage(T("Runtime cache cleared."))
                                         end,
@@ -498,18 +583,18 @@ end
 
 -- Reset when a book is successfully downloaded or when refreshing the menu
 function Zlibrary:resetDownloadQuotaCache()
-    self._runtime_cache:remove("download_quota_status")
+    Config.getConfigRuntimeCache():remove("download_quota_status")
 end
 
 function Zlibrary:getDownloadQuotaCache()
-    return self._runtime_cache:get("download_quota_status", 10800)
+    return Config.getConfigRuntimeCache():get("download_quota_status", 10800)
 end
 
 -- Run completion callback (precheck_ok)
 function Zlibrary:validateDownloadQuota(callback)
     local has_callback = type(callback) == "function"
 
-    local quota_status = self._runtime_cache:get("download_quota_status")
+    local quota_status = Config.getConfigRuntimeCache():get("download_quota_status")
     if type(quota_status) == "table" and next(quota_status) then
         return has_callback and callback(true)
     end
@@ -523,7 +608,7 @@ function Zlibrary:validateDownloadQuota(callback)
         requires_auth = true,
         resolve_result = function(ui_self, api_result, plugin_self)
             if type(api_result) == "table" and type(api_result.quota_status) == "table" then
-                plugin_self._runtime_cache:insert("download_quota_status", api_result.quota_status)
+                Config.getConfigRuntimeCache():insert("download_quota_status", api_result.quota_status)
                 return has_callback and callback(true)                
             else
                 logger.warn("failed to load download quota status")
@@ -534,14 +619,14 @@ function Zlibrary:validateDownloadQuota(callback)
 end
 
 function Zlibrary:isBookInFavorites(book_stub)
-    local cached_ids = self._runtime_cache:get("favorite_book_ids", 1800)
+    local cached_ids = Config.getConfigRuntimeCache():get("favorite_book_ids", 1800)
     if not (book_stub and book_stub.id) then return type(cached_ids) == "table" end
     return type(cached_ids) == "table" and cached_ids[tostring(book_stub.id)] == true
 end
 
 -- Reset when a book is favorited/unfavorited or when refreshing the menu
 function Zlibrary:resetFavoritesCache(is_all)
-    self._runtime_cache:remove("favorite_book_ids")
+    Config.getConfigRuntimeCache():remove("favorite_book_ids")
     if is_all then Cache:new({ name = "multi_search" }):remove("favorites") end
 end
 
@@ -563,7 +648,7 @@ function Zlibrary:validateFavoriteBookIds(callback)
             end
 
             -- Allow favorites to be empty in cache
-            plugin_self._runtime_cache:insert("favorite_book_ids", book_ids)
+            Config.getConfigRuntimeCache():insert("favorite_book_ids", book_ids)
 
             return has_callback and callback(true)
         else

--- a/main.lua
+++ b/main.lua
@@ -51,7 +51,7 @@ function Zlibrary:init()
         logger.warn("self.ui or self.ui.menu not initialized in Zlibrary:init")
     end
 
-    self._runtime_cache = Cache:new({name = "_runtime_cache"})
+    self._runtime_cache = Config.getConfigRuntimeCache()
 end
 
 function Zlibrary:onZlibrarySearch()
@@ -276,6 +276,7 @@ function Zlibrary:addToMainMenu(menu_items)
                                         keep_menu_open = true,
                                         callback = function()
                                             self._runtime_cache:clear()
+                                            Cache:new{ name = "_domains_cache" }:clear()
                                             Ui.showInfoMessage(T("Runtime cache cleared."))
                                         end,
                                     }, {

--- a/main.lua
+++ b/main.lua
@@ -72,6 +72,28 @@ function Zlibrary:autoDiscoverAndSetBaseUrl()
     end
 
     logger.info("Zlibrary:autoDiscoverAndSetBaseUrl - START")
+
+    local domains_cache = Cache:new{ name = "_domains_cache" }
+    local domains = domains_cache:get("domains", 86400)
+    if not domains then
+        logger.info("Zlibrary:autoDiscoverAndSetBaseUrl - Domains not in cache, fetching from remote...")
+        local response = Api.fetchDynamicDomains()
+        if response.success and response.domains and type(response.domains.domains) == "table" then
+            local flat_domains = {}
+            for _, item in ipairs(response.domains.domains) do
+                if type(item.domain) == "string" then
+                    table.insert(flat_domains, item.domain)
+                end
+            end
+            if #flat_domains > 0 then
+                logger.info(string.format("Zlibrary:autoDiscoverAndSetBaseUrl - Successfully extracted %d domains, updating cache", #flat_domains))
+                domains_cache:insert("domains", flat_domains) 
+            else
+                logger.warn("Zlibrary:autoDiscoverAndSetBaseUrl - Remote fetch succeeded, but no valid domains were extracted")
+            end
+        end
+    end
+
     local result = Api.findWorkingBaseUrl()
     
     if result.success and result.url then

--- a/main.lua
+++ b/main.lua
@@ -263,11 +263,13 @@ function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
 
                 if event == "START" then
                     item.mandatory = "\u{27F3} " .. T("Checking")
+                    item.mandatory_dim = false
                     item.bold = true
                 elseif event == "END" then
                     item.bold = false
                     if check_result.success then
                         item.mandatory = string.format("\u{2714} %dms", check_result.elapsed or 0)
+                        item.mandatory_dim = false
                         item.callback = function()
                             local ok, err_msg = Config.setAndValidateBaseUrl(check_result.url)
                             if ok then
@@ -286,10 +288,10 @@ function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
                     end
                 end
                 
-                connection_menu:switchItemTable(nil, nil, update_item_index)
                 connection_menu:updateItems(nil, true)
                 -- only one frame, need immediate refresh.
                 UIManager:forceRePaint()
+                connection_menu:switchItemTable(nil, nil, update_item_index)
             end
         end
     end

--- a/main.lua
+++ b/main.lua
@@ -64,7 +64,7 @@ end
 
 function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
     if NetworkMgr:willRerunWhenOnline(function()
-        self:autoDiscoverAndSetBaseUrl(is_interactive)
+        self:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
     end) then
         return { success = false, error = T("Network not available. Please connect and try again.") }
     end
@@ -76,7 +76,7 @@ function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
     local updateDomainsCache = function()
         logger.info("Zlibrary:autoDiscoverAndSetBaseUrl - Domains not in cache, fetching from remote...")
         local response = Api.fetchDynamicDomains()
-        if response.success and response.domains and type(response.domains.domains) == "table" then
+        if response.success and type(response.domains) == "table" and type(response.domains.domains) == "table" then
             local flat_domains = {}
             for _, item in ipairs(response.domains.domains) do
                 if type(item.domain) == "string" then
@@ -84,8 +84,8 @@ function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
                 end
             end
             if #flat_domains > 0 then
-                logger.info(string.format("Zlibrary:autoDiscoverAndSetBaseUrl - Successfully extracted %d domains", #flat_domains))
                 domains_cache:insert("domains", flat_domains) 
+                logger.info(string.format("Zlibrary:autoDiscoverAndSetBaseUrl - Successfully extracted %d domains", #flat_domains))
             else
                 logger.warn("Zlibrary:autoDiscoverAndSetBaseUrl - Remote fetch succeeded, but no valid domains were extracted")
             end

--- a/main.lua
+++ b/main.lua
@@ -236,14 +236,6 @@ function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
                 end,
             })
             table.insert(menu_items, {
-                text = T("Prioritize Custom BaseUrls"),
-                mandatory = "\u{25B7}",
-                callback = function()
-                    local cred_file_path = self.plugin_path .. Config.CREDENTIALS_FILENAME
-                    Ui.showSimpleMessageDialog("", (string.format(T("Please edit the `seedUrls` list in file `%s` or submit an issue on GitHub."), cred_file_path)))
-                end,
-            })
-            table.insert(menu_items, {
                 text = T("Back"),
                 mandatory = "\u{21A9}",
                 callback = function()
@@ -252,7 +244,7 @@ function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
             })
 
             connection_menu = Ui.showUrlCheckProgress(self, menu_items)
-
+            
             progress_callback = function(event, check_result)
                 if not (connection_menu and connection_menu.item_table) then return end
                 if not (type(check_result) == "table" and type(check_result.index) == "number") then return end
@@ -287,11 +279,15 @@ function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
                         end
                     end
                 end
-                
-                connection_menu:updateItems(nil, true)
+
+                local target_page = connection_menu:getPageNumber(update_item_index)  
+                if connection_menu.page ~= target_page then  
+                    connection_menu:switchItemTable(nil, nil, update_item_index)  
+                else  
+                    connection_menu:updateItems(update_item_index, true)  
+                end 
                 -- only one frame, need immediate refresh.
                 UIManager:forceRePaint()
-                connection_menu:switchItemTable(nil, nil, update_item_index)
             end
         end
     end

--- a/main.lua
+++ b/main.lua
@@ -63,11 +63,10 @@ function Zlibrary:onZlibrarySearch()
 end
 
 function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
-    if NetworkMgr:willRerunWhenOnline(function()
+    -- only automatically enable the network when in non-interactive mode
+    if not is_interactive and NetworkMgr:willRerunWhenOnline(function()
         self:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
-    end) then
-        return { success = false, error = T("Network not available. Please connect and try again.") }
-    end
+    end) then return end
 
     logger.info("Zlibrary:autoDiscoverAndSetBaseUrl - START")
 
@@ -151,7 +150,7 @@ function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
                         local base_status
                         if type(result) == "table" then
                             if result.success then
-                                base_status = string.format("\u{2714} %dms", result.duration or 0)
+                                base_status = string.format("\u{2714} %dms", result.elapsed or 0)
                             elseif result.error then
                                 base_status = "\u{2718} " .. tostring(result.error)
                             end
@@ -175,9 +174,7 @@ function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
                                 end
                                 updateBaseUrlItem(input_value)
                                 return true
-                            end,
-                            base_status
-                        )
+                            end, base_status)
                     end
                     if base_url and base_url ~= "" and NetworkMgr:isConnected() then
                         local loading_msg = Ui.showLoadingMessage(T("Checking") .. "...")
@@ -194,8 +191,13 @@ function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
                 text = T("Auto-discover base URL"),
                 mandatory = "\u{25B7}",
                 callback = function()
-                    local loading_msg = Ui.showLoadingMessage(T("Searching for working Z-library server..."))
-                    AsyncHelper.run(task, on_success, on_error, loading_msg)
+                    if not NetworkMgr:isConnected() then
+                        return Ui.showErrorMessage(T("Network not available. Please connect and try again."))
+                    end
+                    UIManager:nextTick(function()
+                        local loading_msg = Ui.showLoadingMessage(T("Searching for working Z-library server..."))
+                        AsyncHelper.run(task, on_success, on_error, loading_msg)
+                    end)
                 end,
             }, { text = "---" }}
             
@@ -223,6 +225,9 @@ function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
                 text = T("Refresh Dynamic Domains"),
                 mandatory = "\u{25B7}",
                 callback = function()
+                    if not NetworkMgr:isConnected() then
+                        return Ui.showErrorMessage(T("Network not available. Please connect and try again."))
+                    end
                     if connection_menu then UIManager:close(connection_menu) end
                     local loading_msg = Ui.showLoadingMessage(T("Fetching dynamic domains..."))
                     AsyncHelper.run(updateDomainsCache, function()
@@ -262,7 +267,7 @@ function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
                 elseif event == "END" then
                     item.bold = false
                     if check_result.success then
-                        item.mandatory = string.format("\u{2714} %dms", check_result.duration or 0)
+                        item.mandatory = string.format("\u{2714} %dms", check_result.elapsed or 0)
                         item.callback = function()
                             local ok, err_msg = Config.setAndValidateBaseUrl(check_result.url)
                             if ok then
@@ -280,13 +285,11 @@ function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
                         end
                     end
                 end
-
-                UIManager:nextTick(function()
-                    connection_menu:switchItemTable(nil, nil, update_item_index)
-                    connection_menu:updateItems(nil, true)
-                    UIManager:setDirty(connection_menu, "ui")
-                    UIManager:forceRePaint()
-                end)
+                
+                connection_menu:switchItemTable(nil, nil, update_item_index)
+                connection_menu:updateItems(nil, true)
+                -- only one frame, need immediate refresh.
+                UIManager:forceRePaint()
             end
         end
     end
@@ -971,11 +974,15 @@ function Zlibrary:onSelectRecommendedBook(book_stub)
     local book_cache = Cache:new{
             name = string.format("%s_%s", book_stub.id, book_stub.hash)
     }
-    local book_details_cache = book_cache:get("details", 432000)
+    local book_details_cache = book_cache:get("details", 604800)
 
     if type(book_details_cache) == "table" and book_details_cache.title then
         Ui.showBookDetails(self, book_details_cache, function()
                 book_cache:clear()
+                -- also clear comments
+                Cache:new{ 
+                    name = string.format("comments_%s_%s", book_stub.id, book_stub.hash)
+                }:clear()
                 self:onSelectRecommendedBook(book_stub)
         end)
         return
@@ -1494,7 +1501,7 @@ function Zlibrary:fetchAndDisplayComments(book, skip_cache)
             name = string.format("comments_%s_%s", book.id, book.hash)
     }
     if not skip_cache then
-        local book_comments_cache = book_cache:get("comments", 432000)
+        local book_comments_cache = book_cache:get("comments", 604800)
         if type(book_comments_cache) == "table" and book_comments_cache[1] then
             Ui.showCommentsDialog(self, book_comments_cache)
             return

--- a/main.lua
+++ b/main.lua
@@ -94,7 +94,7 @@ function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
 
     local executeDiscovery = function()
         local seed_urls = Config.getSeedUrls()
-        local progress_callback
+        local connection_menu, progress_callback, updateBaseUrlItem
 
         local task = function()
             return Api.findWorkingBaseUrl(seed_urls, progress_callback)
@@ -109,6 +109,7 @@ function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
                         retry_callback() 
                     else
                         Ui.showInfoMessage(T("Successfully found and set base URL to: ") .. result.url)
+                        if type(updateBaseUrlItem) == "function" then updateBaseUrlItem(result.url) end
                     end
                 else
                     logger.warn("Zlibrary:autoDiscoverAndSetBaseUrl - Failed to validate discovered URL: " .. (err_msg or "Unknown error"))
@@ -127,9 +128,70 @@ function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
             local loading_msg = Ui.showLoadingMessage(T("Searching for working Z-library server..."))
             AsyncHelper.run(task, on_success, on_error, loading_msg)
         else
-            local connection_menu
+            local cleanBaseUrl = function(base)
+                return (base and (tostring(base):gsub("^https?://", ""):gsub("/+$", ""))) or ""
+            end
+            updateBaseUrlItem = function(base)
+                if connection_menu and connection_menu.item_table and connection_menu.item_table[1] then
+                    connection_menu.item_table[1].text = string.format("%s [ %s ]", T("Current Base URL:"), cleanBaseUrl(base))
+                    connection_menu:updateItems(nil, true)
+                end
+            end
+
+            local base_url = Config.getBaseUrl(true)
+            local clean_base_url = cleanBaseUrl(base_url)
             local menu_items = {{
-                text = T("Start"),
+                text = string.format("%s  [ %s ]", T("Current Base URL:"), clean_base_url),
+                mandatory = "\u{2699}",
+                callback = function()
+                    -- Could have changed
+                    base_url = Config.getBaseUrl(true)
+                    local showConfigDialog = function(result)
+                        local real_url = Config.getCacheRealUrl()
+                        local base_status
+                        if type(result) == "table" then
+                            if result.success then
+                                base_status = string.format("\u{2714} %dms", result.duration or 0)
+                            elseif result.error then
+                                base_status = "\u{2718} " .. tostring(result.error)
+                            end
+                        elseif type(result) == "string" then 
+                            base_status = result
+                        end
+
+                        if real_url or base_status then
+                            base_status = string.format(" %s \n %s", base_status, (real_url and T("Mirror site redirected to: ") .. tostring(real_url)) or "")
+                        end
+                        Ui.showGenericInputDialog(
+                            T("Set base URL"),
+                            Config.SETTINGS_BASE_URL_KEY,
+                            base_url,
+                            false,
+                            function(input_value)
+                                local success, err_msg = Config.setAndValidateBaseUrl(input_value)
+                                if not success then
+                                    Ui.showErrorMessage(err_msg or T("Invalid Base URL."))
+                                    return false
+                                end
+                                updateBaseUrlItem(input_value)
+                                return true
+                            end,
+                            base_status
+                        )
+                    end
+                    if base_url and base_url ~= "" and NetworkMgr:isConnected() then
+                        local loading_msg = Ui.showLoadingMessage(T("Checking") .. "...")
+                        AsyncHelper.run(function()
+                            return Api.healthCheck(base_url)
+                        end, function(result)
+                            showConfigDialog(result)
+                        end, function(err_msg) showConfigDialog(err_msg) end, loading_msg)
+                    else
+                        showConfigDialog()
+                    end
+                end,
+            }, {
+                text = T("Auto-discover base URL"),
                 mandatory = "\u{25B7}",
                 callback = function()
                     local loading_msg = Ui.showLoadingMessage(T("Searching for working Z-library server..."))
@@ -143,7 +205,7 @@ function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
             for i, seed_item in ipairs(seed_urls) do
                 local raw_url = type(seed_item) == "table" and seed_item.url or tostring(seed_item)
                 local src_str = type(seed_item) == "table" and seed_item.src or "X"
-                local display_url = raw_url:gsub("^https?://", ""):gsub("/$", "")
+                local display_url = cleanBaseUrl(raw_url)
                 table.insert(menu_items, {
                     text = string.format("[%s] %s", src_str, display_url),
                     mandatory = "\u{23F3} " .. T("Queued"),
@@ -164,7 +226,7 @@ function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
                     if connection_menu then UIManager:close(connection_menu) end
                     local loading_msg = Ui.showLoadingMessage(T("Fetching dynamic domains..."))
                     AsyncHelper.run(updateDomainsCache, function()
-                        self:autoDiscoverAndSetBaseUrl(true) 
+                        self:autoDiscoverAndSetBaseUrl(true)
                     end, on_error, loading_msg)
                 end,
             })
@@ -186,18 +248,18 @@ function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
 
             connection_menu = Ui.showUrlCheckProgress(self, menu_items)
 
-            progress_callback = function(status, check_result)
+            progress_callback = function(event, check_result)
                 if not (connection_menu and connection_menu.item_table) then return end
-                if type(check_result) ~= "table" then return end
+                if not (type(check_result) == "table" and type(check_result.index) == "number") then return end
                 
                 local update_item_index = check_result.index + item_index_offset
                 local item = connection_menu.item_table[update_item_index]
                 if not item then return end
 
-                if status == "START" then
+                if event == "START" then
                     item.mandatory = "\u{27F3} " .. T("Checking")
                     item.bold = true
-                elseif status == "END" then
+                elseif event == "END" then
                     item.bold = false
                     if check_result.success then
                         item.mandatory = string.format("\u{2714} %dms", check_result.duration or 0)
@@ -205,12 +267,14 @@ function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
                             local ok, err_msg = Config.setAndValidateBaseUrl(check_result.url)
                             if ok then
                                 Ui.showInfoMessage(string.format("%s : %s", T("Set base URL"), tostring(check_result.url)))
+                                updateBaseUrlItem(check_result.url)
                             else
                                 Ui.showInfoMessage( T("Invalid Base URL.") .. " " .. tostring(err_msg))
                             end
                         end
                     else
                         item.mandatory = "\u{2718} " .. T("Failed")
+                        item.mandatory_dim = true
                         item.callback = function()
                             Ui.showInfoMessage(check_result.error or T("Unknown error"))
                         end
@@ -253,29 +317,8 @@ function Zlibrary:addToMainMenu(menu_items)
                             text = T("Set base URL"),
                             keep_menu_open = true,
                             callback = function()
-                                Ui.showGenericInputDialog(
-                                    T("Set base URL"),
-                                    Config.SETTINGS_BASE_URL_KEY,
-                                    Config.getBaseUrl(true),
-                                    false,
-                                    function(input_value)
-                                        local success, err_msg = Config.setAndValidateBaseUrl(input_value)
-                                        if not success then
-                                            Ui.showErrorMessage(err_msg or T("Invalid Base URL."))
-                                            return false
-                                        end
-                                        return true
-                                    end
-                                )
-                            end,
-                        },
-                        {
-                            text = T("Auto-discover base URL"),
-                            keep_menu_open = true,
-                            callback = function()
                                 UIManager:nextTick(function() self:autoDiscoverAndSetBaseUrl(true) end)
                             end,
-                            separator = true,
                         },
                         {
                             text = T("Set email"),
@@ -928,7 +971,7 @@ function Zlibrary:onSelectRecommendedBook(book_stub)
     local book_cache = Cache:new{
             name = string.format("%s_%s", book_stub.id, book_stub.hash)
     }
-    local book_details_cache = book_cache:get("details")
+    local book_details_cache = book_cache:get("details", 432000)
 
     if type(book_details_cache) == "table" and book_details_cache.title then
         Ui.showBookDetails(self, book_details_cache, function()

--- a/main.lua
+++ b/main.lua
@@ -63,231 +63,239 @@ function Zlibrary:onZlibrarySearch()
 end
 
 function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
-    -- only automatically enable the network when in non-interactive mode
     if not is_interactive and NetworkMgr:willRerunWhenOnline(function()
         self:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
     end) then return end
 
     logger.info("Zlibrary:autoDiscoverAndSetBaseUrl - START")
 
+    local function getCleanUrl(url)
+        if type(url) ~= "string" then return "" end
+        local clean_str = url:gsub("^https?://", ""):gsub("/+$", "")
+        return clean_str
+    end
+
     local domains_cache = Cache:new{ name = "_domains_cache" }
 
-    local updateDomainsCache = function()
-        logger.info("Zlibrary:autoDiscoverAndSetBaseUrl - Domains not in cache, fetching from remote...")
+    local function updateDomainsCache()
+        logger.info("Zlibrary - Fetching dynamic domains...")
         local response = Api.fetchDynamicDomains()
         if response.success and type(response.domains) == "table" and type(response.domains.domains) == "table" then
-            local flat_domains = {}
+            local flat = {}
             for _, item in ipairs(response.domains.domains) do
-                if type(item.domain) == "string" then
-                    table.insert(flat_domains, item.domain)
-                end
+                if type(item.domain) == "string" then table.insert(flat, item.domain) end
             end
-            if #flat_domains > 0 then
-                domains_cache:insert("domains", flat_domains) 
-                logger.info(string.format("Zlibrary:autoDiscoverAndSetBaseUrl - Successfully extracted %d domains", #flat_domains))
-            else
-                logger.warn("Zlibrary:autoDiscoverAndSetBaseUrl - Remote fetch succeeded, but no valid domains were extracted")
-            end
+            if #flat > 0 then domains_cache:insert("domains", flat) end
         end
     end
 
-    local executeDiscovery = function()
-        local seed_urls = Config.getSeedUrls()
-        local connection_menu, progress_callback, updateBaseUrlItem
-
-        local task = function()
-            return Api.findWorkingBaseUrl(seed_urls, progress_callback)
-        end                    
-        
-        local on_success = function(result)
-            if result.success and result.url then
-                local success, err_msg = Config.setAndValidateBaseUrl(result.url)
-                if success then
-                    logger.info("Zlibrary:autoDiscoverAndSetBaseUrl - Successfully set base URL to: " .. result.url)
-                    if is_interactive ~= true and type(retry_callback) == "function" then 
-                        retry_callback() 
-                    else
-                        Ui.showInfoMessage(T("Successfully found and set base URL to: ") .. result.url)
-                        if type(updateBaseUrlItem) == "function" then updateBaseUrlItem(result.url) end
-                    end
-                else
-                    logger.warn("Zlibrary:autoDiscoverAndSetBaseUrl - Failed to validate discovered URL: " .. (err_msg or "Unknown error"))
-                end    
-            else
-                logger.warn("Zlibrary:autoDiscoverAndSetBaseUrl - Failed to discover working base URL")
-                Ui.showErrorMessage(result.error or T("Failed to find a working base URL."))
+    local function executeDiscovery()
+        local valid_seeds = {}
+        for _, item in ipairs(Config.getSeedUrls() or {}) do
+            local raw_url = type(item) == "table" and item.url or item
+            if type(raw_url) == "string" and raw_url ~= "" then
+                table.insert(valid_seeds, { url = raw_url:gsub("/$", ""), src = type(item) == "table" and item.src or "X" })
             end
-        end                  
-        
-        local on_error = function(err_msg)
-            Ui.showErrorMessage(T("Error during auto-discovery: ") .. tostring(err_msg))
         end
 
-        if is_interactive ~= true then
-            local loading_msg = Ui.showLoadingMessage(T("Searching for working Z-library server..."))
-            AsyncHelper.run(task, on_success, on_error, loading_msg)
-        else
-            local cleanBaseUrl = function(base)
-                return (base and (tostring(base):gsub("^https?://", ""):gsub("/+$", ""))) or ""
-            end
-            updateBaseUrlItem = function(base)
-                if connection_menu and connection_menu.item_table and connection_menu.item_table[1] then
-                    connection_menu.item_table[1].text = string.format("%s [ %s ]", T("Current Base URL:"), cleanBaseUrl(base))
-                    connection_menu:updateItems(nil, true)
-                end
-            end
+        local connection_menu, progress_callback, updateBaseUrlItem
+        local findWorkingBaseUrl = AsyncHelper:createChannel("findWorkingBaseUrl", 3)
+        local first_working_url, loading_msg = nil, nil
+        -- task status lock
+        local is_discovering = false
+        local common_task_func = function(url) return Api.healthCheck(url, true) end
 
-            local base_url = Config.getBaseUrl(true)
-            local clean_base_url = cleanBaseUrl(base_url)
-            local menu_items = {{
-                text = string.format("%s  [ %s ]", T("Current Base URL:"), clean_base_url),
+        local function finishDiscovery(result_url)
+            is_discovering = false
+            if loading_msg then 
+                UIManager:close(loading_msg)
+                loading_msg = nil 
+            end
+            if result_url then
+                local ok, err = Config.setAndValidateBaseUrl(result_url)
+                if ok then
+                    if not is_interactive and type(retry_callback) == "function" then
+                        retry_callback()
+                    else
+                        Ui.showInfoMessage(T("Successfully set base URL to: ") .. result_url)
+                        if updateBaseUrlItem then updateBaseUrlItem(result_url) end
+                    end
+                else
+                    logger.warn("Zlibrary - URL validation failed: " .. tostring(err))
+                end
+            elseif not is_interactive then
+                Ui.showErrorMessage(T("Failed to find a working base URL."))
+            end
+        end
+
+        local function start_discover_task()
+            findWorkingBaseUrl:clearTasks()
+            first_working_url = nil
+            
+            local valid_count = #valid_seeds
+            if valid_count == 0 then return finishDiscovery() end
+
+            local completed_count = 0
+            for i, seed in ipairs(valid_seeds) do
+                local on_start = progress_callback and function() progress_callback("START", i, seed) end
+                local on_end = function(_, result)
+                    completed_count = completed_count + 1
+                    if type(result) ~= "table" then result = {} end
+                    
+                    if progress_callback then progress_callback("END", i, seed, result) end
+
+                    if result.success and not first_working_url then
+                        first_working_url = seed.url
+                        if not is_interactive then
+                            findWorkingBaseUrl:clearTasks()
+                            finishDiscovery(first_working_url)
+                        end
+                    end
+                    if completed_count == valid_count then finishDiscovery(first_working_url) end
+                end
+
+                findWorkingBaseUrl:pushTask(common_task_func, on_end, {args = {seed.url}, on_start = on_start})
+            end
+        end
+
+        if not is_interactive then 
+            -- block until done
+            loading_msg = Ui.showLoadingMessage(T("Searching for working Z-library server..."))
+            return start_discover_task() 
+         end
+
+        -- interactive part
+        updateBaseUrlItem = function(base)
+            if connection_menu and connection_menu.item_table and connection_menu.item_table[1] then
+                connection_menu.item_table[1].text = string.format("%s [ %s ]", T("Current Base URL:"), getCleanUrl(base))
+                connection_menu:updateItems(nil, true)
+            end
+        end
+
+        local check_status, max_idx
+        local menu_items = {
+            {
+                text = string.format("%s  [ %s ]", T("Current Base URL:"), getCleanUrl(Config.getBaseUrl(true))),
                 mandatory = "\u{2699}",
                 callback = function()
-                    -- Could have changed
-                    base_url = Config.getBaseUrl(true)
-                    local showConfigDialog = function(result)
-                        local real_url = Config.getCacheRealUrl()
-                        local base_status
-                        if type(result) == "table" then
-                            if result.success then
-                                base_status = string.format("\u{2714} %dms", result.elapsed or 0)
-                            elseif result.error then
-                                base_status = "\u{2718} " .. tostring(result.error)
-                            end
-                        elseif type(result) == "string" then 
-                            base_status = result
-                        end
-
-                        if real_url or base_status then
-                            base_status = string.format(" %s \n %s", base_status, (real_url and T("Mirror site redirected to: ") .. tostring(real_url)) or "")
-                        end
-                        Ui.showGenericInputDialog(
-                            T("Set base URL"),
-                            Config.SETTINGS_BASE_URL_KEY,
-                            base_url,
-                            false,
-                            function(input_value)
-                                local success, err_msg = Config.setAndValidateBaseUrl(input_value)
-                                if not success then
-                                    Ui.showErrorMessage(err_msg or T("Invalid Base URL."))
-                                    return false
-                                end
-                                updateBaseUrlItem(input_value)
-                                return true
-                            end, base_status)
+                    local base = Config.getBaseUrl(true)
+                    local real = Config.getCacheRealUrl()
+                    
+                    local build_dialog
+                    build_dialog = function(val, info)
+                        return Ui.showGenericInputDialog(T("Set base URL"), Config.SETTINGS_BASE_URL_KEY, val, false, function(in_val)
+                            local ok, err = Config.setAndValidateBaseUrl(in_val)
+                            if ok then updateBaseUrlItem(in_val); return true end
+                            Ui.showErrorMessage(err or T("Invalid Base URL.")); return false
+                        end, info)
                     end
-                    if base_url and base_url ~= "" and NetworkMgr:isConnected() then
-                        local loading_msg = Ui.showLoadingMessage(T("Checking") .. "...")
-                        AsyncHelper.run(function()
-                            return Api.healthCheck(base_url)
-                        end, function(result)
-                            showConfigDialog(result)
-                        end, function(err_msg) showConfigDialog(err_msg) end, loading_msg)
-                    else
-                        showConfigDialog()
-                    end
-                end,
-            }, {
-                text = T("Auto-discover base URL"),
-                mandatory = "\u{25B7}",
-                callback = function()
-                    if not NetworkMgr:isConnected() then
-                        return Ui.showErrorMessage(T("Network not available. Please connect and try again."))
-                    end
-                    UIManager:nextTick(function()
-                        local loading_msg = Ui.showLoadingMessage(T("Searching for working Z-library server..."))
-                        AsyncHelper.run(task, on_success, on_error, loading_msg)
-                    end)
-                end,
-            }, { text = "---" }}
-            
-            local item_index_offset = #menu_items
-            local has_clipboard = Device:hasClipboard()
-
-            for i, seed_item in ipairs(seed_urls) do
-                local raw_url = type(seed_item) == "table" and seed_item.url or tostring(seed_item)
-                local src_str = type(seed_item) == "table" and seed_item.src or "X"
-                local display_url = cleanBaseUrl(raw_url)
-                table.insert(menu_items, {
-                    text = string.format("[%s] %s", src_str, display_url),
-                    mandatory = "\u{23F3} " .. T("Queued"),
-                    show_indicator = false,
-                    callback = has_clipboard and function()
-                        local c_text = display_url
-                        Device.input.setClipboardText(string.format("https://%s", c_text))
-                        Ui.showInfoMessage(T("Selection copied to clipboard."))
-                    end or nil,
-                })
-            end
-            
-            table.insert(menu_items, { text = "---" })
-            table.insert(menu_items, {
-                text = T("Refresh Dynamic Domains"),
-                mandatory = "\u{25B7}",
-                callback = function()
-                    if not NetworkMgr:isConnected() then
-                        return Ui.showErrorMessage(T("Network not available. Please connect and try again."))
-                    end
-                    if connection_menu then UIManager:close(connection_menu) end
-                    local loading_msg = Ui.showLoadingMessage(T("Fetching dynamic domains..."))
-                    AsyncHelper.run(updateDomainsCache, function()
-                        self:autoDiscoverAndSetBaseUrl(true)
-                    end, on_error, loading_msg)
-                end,
-            })
-            table.insert(menu_items, {
-                text = T("Back"),
-                mandatory = "\u{21A9}",
-                callback = function()
-                    if connection_menu then UIManager:close(connection_menu) end
-                end,
-            })
-
-            connection_menu = Ui.showUrlCheckProgress(self, menu_items)
-            
-            progress_callback = function(event, check_result)
-                if not (connection_menu and connection_menu.item_table) then return end
-                if not (type(check_result) == "table" and type(check_result.index) == "number") then return end
-                
-                local update_item_index = check_result.index + item_index_offset
-                local item = connection_menu.item_table[update_item_index]
-                if not item then return end
-
-                if event == "START" then
-                    item.mandatory = "\u{27F3} " .. T("Checking")
-                    item.mandatory_dim = false
-                    item.bold = true
-                elseif event == "END" then
-                    item.bold = false
-                    if check_result.success then
-                        item.mandatory = string.format("\u{2714} %dms", check_result.elapsed or 0)
-                        item.mandatory_dim = false
-                        item.callback = function()
-                            local ok, err_msg = Config.setAndValidateBaseUrl(check_result.url)
-                            if ok then
-                                Ui.showInfoMessage(string.format("%s : %s", T("Set base URL"), tostring(check_result.url)))
-                                updateBaseUrlItem(check_result.url)
-                            else
-                                Ui.showInfoMessage( T("Invalid Base URL.") .. " " .. tostring(err_msg))
-                            end
+                    
+                    local dlg = build_dialog(base, real and (T("Mirror site redirected to: ") .. real) or nil)
+                    
+                    if base and base ~= "" and NetworkMgr:isConnected() then
+                        if not check_status then
+                            -- with debounce
+                            check_status = UIManager:debounce(12, true, function()
+                                findWorkingBaseUrl:pushTask(common_task_func, function(_, res)
+                                if type(res) ~= "table" then res = {} end
+                                    local status = res.success and string.format("\u{2714} %dms", res.elapsed or 0) or ("\u{2718} " .. tostring(res.error or ""))
+                                    real = Config.getCacheRealUrl()
+                                    local final_info = string.format(" %s \n %s", status, real and (T("Mirror site redirected to: ") .. real) or "")
+                                    if dlg then
+                                        pcall(function()
+                                            local txt = dlg:getInputText()
+                                            UIManager:close(dlg)
+                                            dlg = build_dialog(txt, final_info)
+                                        end)
+                                    end
+                                end, {args = {base}})
+                            end)
                         end
-                    else
-                        item.mandatory = "\u{2718} " .. T("Failed")
-                        item.mandatory_dim = true
-                        item.callback = function()
-                            Ui.showInfoMessage(check_result.error or T("Unknown error"))
-                        end
+                        check_status()
                     end
                 end
+            }, {
+                text = T("Auto-discover base URL"), 
+                mandatory = "\u{25B7}",
+                callback = function()
+                    if not NetworkMgr:isConnected() then return Ui.showErrorMessage(T("Network unavailable.")) end
+                    if is_discovering then return Ui.showInfoMessage(T("Discovery is already running...")) end
+                    -- back to first page
+                    max_idx = 1
+                    is_discovering = true
+                    UIManager:nextTick(start_discover_task)
+                end
+            }, { text = "---" }
+        }
 
-                local target_page = connection_menu:getPageNumber(update_item_index)  
-                if connection_menu.page ~= target_page then  
-                    connection_menu:switchItemTable(nil, nil, update_item_index)  
-                else  
-                    connection_menu:updateItems(update_item_index, true)  
-                end 
-                -- only one frame, need immediate refresh.
-                UIManager:forceRePaint()
+        local offset = #menu_items
+        for _, seed in ipairs(valid_seeds) do
+            local d_url = getCleanUrl(seed.url)
+            table.insert(menu_items, {
+                text = string.format("[%s] %s", seed.src, d_url),
+                mandatory = "\u{23F3} " .. T("Queued"),
+                show_indicator = false,
+                callback = Device:hasClipboard() and function()
+                    Device.input.setClipboardText("https://" .. d_url)
+                    Ui.showInfoMessage(T("Selection copied to clipboard."))
+                end or nil
+            })
+        end
+        
+        table.insert(menu_items, { text = "---" })
+        table.insert(menu_items, {
+            text = T("Refresh Dynamic Domains"), mandatory = "\u{25B7}", callback = function()
+                if not NetworkMgr:isConnected() then return Ui.showErrorMessage(T("Network unavailable.")) end
+                if connection_menu then UIManager:close(connection_menu) end
+                AsyncHelper.run(updateDomainsCache, function() self:autoDiscoverAndSetBaseUrl(true) end, 
+                    function(err) Ui.showErrorMessage(tostring(err)) end, Ui.showLoadingMessage(T("Fetching dynamic domains...")))
+        end})
+        table.insert(menu_items, { text = T("Back"), mandatory = "\u{21A9}", callback = function()
+            if connection_menu and connection_menu.onFirstPage then 
+                connection_menu:onFirstPage()
+            end
+        end})
+
+        max_idx = 1
+        connection_menu = Ui.showUrlCheckProgress(self, menu_items, function() 
+            findWorkingBaseUrl:clearTasks()
+            is_discovering = false
+            first_working_url = nil
+        end)
+
+        progress_callback = function(event, idx, seed, res)
+            local item = connection_menu and connection_menu.item_table[idx + offset]
+            if not item then return end
+
+            if event == "START" then
+                item.mandatory, item.bold, item.mandatory_dim = "\u{27F3} " .. T("Checking"), true, false
+            elseif event == "END" then
+                item.bold = false
+                if res.success then
+                    local success_url = seed.url
+                    item.mandatory, item.mandatory_dim = string.format("\u{2714} %dms", res.elapsed or 0), false
+                    item.callback = function()
+                        local ok, err = Config.setAndValidateBaseUrl(success_url)
+                        if ok then
+                            Ui.showInfoMessage(string.format("%s : %s", T("Set base URL"), success_url))
+                            updateBaseUrlItem(success_url)
+                        else
+                            Ui.showErrorMessage(T("Invalid Base URL.") .. " " .. tostring(err))
+                        end
+                    end
+                else
+                    item.mandatory, item.mandatory_dim = "\u{2718} " .. T("Failed"), true
+                    item.callback = function() Ui.showInfoMessage(res.error or T("Unknown error")) end
+                end
+            end
+
+            local update_idx = idx + offset
+            max_idx = math.max(max_idx, update_idx)
+            -- only go forward
+            if connection_menu.page < connection_menu:getPageNumber(max_idx) then
+                connection_menu:switchItemTable(nil, nil, max_idx)
+            else
+                connection_menu:updateItems(update_idx, true)
             end
         end
     end
@@ -295,11 +303,10 @@ function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
     if domains_cache:get("domains", 172800) then
         executeDiscovery()
     else
-        local loading_msg = Ui.showLoadingMessage(T("Fetching dynamic domains..."))
         AsyncHelper.run(updateDomainsCache, executeDiscovery, function(err)
             Ui.showErrorMessage(T("Failed to fetch domains: ") .. tostring(err))
             executeDiscovery()
-        end, loading_msg)
+        end, Ui.showLoadingMessage(T("Fetching dynamic domains...")))
     end
 end
 

--- a/zlibrary/api.lua
+++ b/zlibrary/api.lua
@@ -1271,4 +1271,43 @@ function Api.getBookComments(user_id, user_key, book_id)
     }
 end
 
+function Api.fetchDynamicDomains(repo_path)
+    -- local repo = repo_path or "ZlibraryKO/zlibrary.koplugin"
+    -- local url = string.format("https://raw.githubusercontent.com/%s/main/domains.json", repo)
+
+    -- test
+    local url = "https://z-lib.gd/eapi/info/domains"
+    logger.info(string.format("Api.fetchDynamicDomains - START - URL: %s", url))
+
+    local http_result = Api.makeHttpRequest{
+        url = url,
+        method = "GET",
+        headers = {
+            ["User-Agent"] = Config.USER_AGENT,
+            ["Accept"] = "application/json"
+        },
+        timeout = {5, 10},
+        redirect = true,
+    }
+
+    if http_result.error then
+        logger.warn("Api.fetchDynamicDomains - HTTP request error: ", http_result.error)
+        return { success = false, error = http_result.error }
+    end
+
+    if not http_result.body or http_result.body == "" then
+        logger.warn("Api.fetchDynamicDomains - No response body")
+        return { success = false }
+    end
+
+    local success, data = pcall(json.decode, http_result.body, json.decode.simple)
+    if not success or type(data) ~= "table" then
+        logger.warn("Api.fetchDynamicDomains - Failed to decode JSON: ", http_result.body)
+        return { success = false }
+    end
+
+    logger.info("Api.fetchDynamicDomains - END (Success)")
+    return { success = true, domains = data }
+end
+
 return Api

--- a/zlibrary/api.lua
+++ b/zlibrary/api.lua
@@ -1155,14 +1155,8 @@ function Api.favoriteBook(user_id, user_key, book_stub)
 end
 
 function Api.healthCheck(baseUrl, skip_redir_cache, redir_url)
-    local url
     local is_redir_callback = (type(redir_url) == "string")
-
-    if not is_redir_callback then
-        url = baseUrl .. "/eapi/info/ok"
-    else
-        url = redir_url .. "/eapi/info/ok"
-    end
+    local url = (is_redir_callback and redir_url or baseUrl) .. "/eapi/info/ok"
 
     local start_time = time.now()
     local http_result = Api.makeHttpRequest{
@@ -1175,15 +1169,15 @@ function Api.healthCheck(baseUrl, skip_redir_cache, redir_url)
         skipRedirectCache = skip_redir_cache or false,
         onRedirect = (not is_redir_callback) and function()
             return function(redir_res)
-                local next_base_url = redir_res and redir_res.real_url_base
+                local next_base_url = redir_res and redir_res.real_url_base or nil
                 return Api.healthCheck(baseUrl, skip_redir_cache, next_base_url)
             end
         end,
     }
 
+    if is_redir_callback then return http_result end
     local elapsed = time.to_ms(time.since(start_time)) 
 
-    if is_redir_callback then return http_result end
     if http_result.error then
         logger.dbg("Api.healthCheck - Failed for " .. baseUrl .. ": " .. tostring(http_result.error))
         return { success = false, error = http_result.error }
@@ -1221,8 +1215,8 @@ function Api.findWorkingBaseUrl(seed_urls, progress_callback)
     if type(seed_urls) ~= "table" then
         seed_urls = Config.getSeedUrls() or {}
     end
-    local is_fast = type(progress_callback) ~= "function" 
-    if is_fast then progress_callback=function(a, b) end end
+    local find_first_match = type(progress_callback) ~= "function" 
+    if find_first_match then progress_callback=function(a, b) end end
     local first_working_url
 
     local total_urls = #seed_urls
@@ -1251,7 +1245,7 @@ function Api.findWorkingBaseUrl(seed_urls, progress_callback)
         if result.success then
             if not first_working_url then first_working_url = clean_url end
             logger.info(string.format("Api.findWorkingBaseUrl - Found working URL: %s", clean_url))
-            if is_fast then return { success = true, url = clean_url } end
+            if find_first_match then return { success = true, url = clean_url } end
         end
         ::continue::
     end

--- a/zlibrary/api.lua
+++ b/zlibrary/api.lua
@@ -1189,11 +1189,9 @@ end
 function Api.findWorkingBaseUrl()
     logger.info("Api.findWorkingBaseUrl - START - Checking SEED_URLS")
     
-    for i, seed_url in ipairs(Config.SEED_URLS) do
-        local clean_url = seed_url
-        if string.sub(clean_url, -1) == "/" then
-            clean_url = string.sub(clean_url, 1, -2)
-        end
+    local seed_urls = Config.getSeedUrls() or {}
+    for i, seed_url in ipairs(seed_urls) do
+        local clean_url = seed_url:gsub("/$", "")
         
         logger.info(string.format("Api.findWorkingBaseUrl - Trying [%d/%d]: %s", i, #Config.SEED_URLS, clean_url))
         

--- a/zlibrary/api.lua
+++ b/zlibrary/api.lua
@@ -1,4 +1,5 @@
 local Config = require("zlibrary.config")
+local time = require("ui/time") 
 local util = require("util")
 local logger = require("logger")
 local json = require("json")
@@ -85,11 +86,21 @@ end
 local function _checkAndHandleRedirect(skip_check, status_code, current_url)
 
     local result = { has_redirect = nil, real_url = nil, status_code = nil, error = nil }
-    if skip_check or type(current_url) ~= "string" or current_url == "" or (status_code ~= 301 and 
-                    status_code ~= 302 and status_code ~= 303 and status_code ~= 307) then
+    local redirect_codes = { [301] = true, [302] = true, [303] = true, [307] = true }
+    if skip_check or type(current_url) ~= "string" or current_url == "" or 
+        type(status_code) ~= "number" or not redirect_codes[status_code]  then
             return result
     end
     
+    local current_url_parse = socket_url.parse(current_url)
+    local current_url_base = socket_url.build({
+                scheme = current_url_parse.scheme,
+                host = current_url_parse.host
+        })
+
+    logger.dbg("Request URL: " .. current_url .. ", Redirect Target: " .. current_url_base ..
+           ", Status Code: " .. tostring(status_code) .. ", Is Redirect: " .. tostring(redirect_codes[status_code]))
+
     local http_result = Api.makeHttpRequest({
         url = current_url,
         method = "HEAD",
@@ -103,19 +114,20 @@ local function _checkAndHandleRedirect(skip_check, status_code, current_url)
 
     local real_url = http_result.headers and (http_result.headers.location or http_result.headers.Location)
     if type(real_url) ~= "string" or real_url == "" then
+        logger.err("Redirect failed: empty Location header.", http_result.headers)
         result.error = string.format("Redirect failed: empty Location header. %s", tostring(http_result.error))
         return result
     end
 
     local real_url_parse = socket_url.parse(real_url)
     local real_url_host = real_url_parse.host
-    if real_url_host and real_url_parse.scheme and real_url_host ~= socket_url.parse(current_url).host then
-
-        Config.setCacheRealUrl(current_url, socket_url.build({
+    if real_url_host and real_url_parse.scheme and real_url_host ~= current_url_parse.host then
+        
+        result.real_url = real_url
+        result.real_url_base = socket_url.build({
                 scheme = real_url_parse.scheme,
                 host = real_url_host
-        }))
-        result.real_url = real_url
+        })
     else
         result.error = string.format("Invalid or unchanged Location header. %s", tostring(http_result.error))
     end
@@ -223,15 +235,23 @@ function Api.makeHttpRequest(options)
         return result
     end
 
-    local is_skip_check = not (request_params.method == "GET" and type(options.getRedirectedUrl) == "function")
-    local check_result = _checkAndHandleRedirect(is_skip_check, result.status_code, options.url)
-    if check_result.has_redirect then
-        if check_result.real_url then
-            options.url = options.getRedirectedUrl()
-            options.getRedirectedUrl = nil
-            return Api.makeHttpRequest(options)
-        elseif check_result.error then
-            result = check_result
+    local skip_redirect_check = options.redirect or type(options.onRedirect) ~= "function"
+    local redir_res = _checkAndHandleRedirect(skip_redirect_check, result.status_code, options.url)
+    if redir_res.has_redirect then
+        if redir_res.real_url and redir_res.real_url_base then
+            if not options.skipRedirectCache then
+                Config.setCacheRealUrl(options.url, redir_res.real_url_base)
+            end
+            local redirect_next_step = options.onRedirect()
+            if type(redirect_next_step) == "string" then
+                options.url = redirect_next_step
+                options.onRedirect = nil
+                return Api.makeHttpRequest(options)
+            elseif type(redirect_next_step) == "function" then
+                 return redirect_next_step(redir_res)
+            end
+        elseif redir_res.error then
+            result = redir_res
         end
     end
 
@@ -251,7 +271,7 @@ function Api.makeHttpRequest(options)
     return result
 end
 
-function Api.login(email, password, is_retry)
+function Api.login(email, password, is_redir_callback)
     logger.info(string.format("Zlibrary:Api.login - START"))
     local result = { user_id = nil, user_key = nil, error = nil }
 
@@ -286,17 +306,13 @@ function Api.login(email, password, is_retry)
         timeout = Config.getLoginTimeout(),
         -- Avoid redirects - 301/302 convert POST to GET per RFC.
         redirect = false,
+        -- retry after URL redirection
+        onRedirect = (not is_redir_callback) and function()
+            return function(redir_res) return Api.login(email, password, true) end
+        end,
     }
 
-    local check_result = _checkAndHandleRedirect(is_retry, http_result.status_code, login_url)
-    if check_result.has_redirect then
-        if check_result.real_url then
-            return Api.login(email, password, true)
-        elseif check_result.error then
-            http_result = check_result
-        end
-    end
-
+    if is_redir_callback then return http_result end
     if not http_result.body or http_result.body == "" then
         result.error = http_result.error or T("Login failed: Empty response from server")
         logger.err(string.format("Zlibrary:Api.login - END (Empty body) - Error: %s", result.error))
@@ -344,7 +360,7 @@ function Api.login(email, password, is_retry)
     return result
 end
 
-function Api.search(query, user_id, user_key, languages, extensions, order, page, is_retry)
+function Api.search(query, user_id, user_key, languages, extensions, order, page, is_redir_callback)
     logger.info(string.format("Zlibrary:Api.search - START - Query: %s, Page: %s", query, tostring(page)))
     local result = { results = nil, total_count = nil, error = nil }
 
@@ -397,17 +413,12 @@ function Api.search(query, user_id, user_key, languages, extensions, order, page
         headers = headers,
         source = ltn12.source.string(body),
         timeout = Config.getSearchTimeout(),
+        onRedirect = (not is_redir_callback) and function()
+            return function(redir_res) return Api.search(query, user_id, user_key, languages, extensions, order, page, true) end
+        end,
     }
 
-    local check_result = _checkAndHandleRedirect(is_retry, http_result.status_code, search_url)
-    if check_result.has_redirect then
-        if check_result.real_url then
-            return Api.search(query, user_id, user_key, languages, extensions, order, page, true)
-        elseif check_result.error then
-            http_result = check_result
-        end
-    end  
-
+    if is_redir_callback then return http_result end
     if http_result.error then
         result.error = http_result.error
         result.status_code = http_result.status_code
@@ -590,7 +601,7 @@ function Api.getRecommendedBooks(user_id, user_key)
         method = "GET",
         headers = headers,
         timeout = Config.getRecommendedTimeout(),
-        getRedirectedUrl = Config.getRecommendedBooksUrl,
+        onRedirect = Config.getRecommendedBooksUrl,
     }
     
     if http_result.error then
@@ -638,7 +649,7 @@ function Api.getMostPopularBooks(user_id, user_key)
         method = "GET",
         headers = headers,
         timeout = Config.getPopularTimeout(),
-        getRedirectedUrl = Config.getMostPopularBooksUrl,
+        onRedirect = Config.getMostPopularBooksUrl,
     }
 
     if http_result.error then
@@ -686,7 +697,7 @@ function Api.getBookDetails(user_id, user_key, book_id, book_hash)
         method = "GET",
         headers = headers,
         timeout = Config.getBookDetailsTimeout(),
-        getRedirectedUrl = function()
+        onRedirect = function()
             return Config.getBookDetailsUrl(book_id, book_hash)
         end,
     }
@@ -741,7 +752,7 @@ function Api.getDownloadLink(user_id, user_key, book_id, book_hash)
         method = "GET",
         headers = headers,
         timeout = Config.getBookDetailsTimeout(),
-        getRedirectedUrl = function()
+        onRedirect = function()
             return Config.getDownloadLinkUrl(book_id, book_hash)
         end,
     }
@@ -804,7 +815,7 @@ function Api.getSimilarBooks(user_id, user_key, book_id, book_hash)
         method = "GET",
         headers = headers,
         timeout = Config.getPopularTimeout(),
-        getRedirectedUrl = function()
+        onRedirect = function()
             return Config.getSimilarBooksUrl(book_id, book_hash)
         end,
     }
@@ -857,7 +868,7 @@ function Api.getDownloadedBooks(user_id, user_key, page, order)
         method = "GET",
         headers = headers,
         timeout = Config.getPopularTimeout(),
-        getRedirectedUrl = function()
+        onRedirect = function()
             return Config.getDownloadedBooksUrl(page, order)
         end,
     }
@@ -916,7 +927,7 @@ function Api.getFavoriteBooks(user_id, user_key, page, order)
         method = "GET",
         headers = headers,
         timeout = Config.getPopularTimeout(),
-        getRedirectedUrl = function()
+        onRedirect = function()
             return Config.getFavoriteBooksUrl(page, order)
         end,
     }
@@ -971,7 +982,7 @@ function Api.unfavoriteBook(user_id, user_key, book_stub)
         method = "GET",
         headers = headers,
         timeout = Config.getPopularTimeout(),
-        getRedirectedUrl = function()
+        onRedirect = function()
             return Config.getUnFavoriteUrl(book_stub.id)
         end,
     }
@@ -1020,7 +1031,7 @@ function Api.getDownloadQuotaStatus(user_id, user_key)
         method = "GET",
         headers = headers,
         timeout = Config.getPopularTimeout(),
-        getRedirectedUrl = Config.getDownloadQuotaUrl,
+        onRedirect = Config.getDownloadQuotaUrl,
     }
 
     if http_result.error then
@@ -1067,7 +1078,7 @@ function Api.getFavoriteBookIds(user_id, user_key)
         method = "GET",
         headers = headers,
         timeout = Config.getPopularTimeout(),
-        getRedirectedUrl = Config.getFavoriteBookIdsUrl,
+        onRedirect = Config.getFavoriteBookIdsUrl,
     }
 
     if http_result.error then
@@ -1114,7 +1125,7 @@ function Api.favoriteBook(user_id, user_key, book_stub)
         method = "GET",
         headers = headers,
         timeout = Config.getPopularTimeout(),
-        getRedirectedUrl = function()
+        onRedirect = function()
             return Config.getFavoriteUrl(book_stub.id)
         end,
     }
@@ -1143,13 +1154,17 @@ function Api.favoriteBook(user_id, user_key, book_stub)
     return { success = true }
 end
 
-function Api.healthCheck()
-    local url = Config.getHealthCheckUrl()
-    if not url then
-        logger.warn("Api.healthCheck - Base URL not configured")
-        return { error = T("Z-library server URL not configured.") }
+function Api.healthCheck(baseUrl, skip_redir_cache, redir_url)
+    local url
+    local is_redir_callback = (type(redir_url) == "string")
+
+    if not is_redir_callback then
+        url = baseUrl .. "/eapi/info/ok"
+    else
+        url = redir_url .. "/eapi/info/ok"
     end
-    local baseUrl = Config.getBaseUrl(true)
+
+    local start_time = time.now()
     local http_result = Api.makeHttpRequest{
         url = url,
         method = "GET",
@@ -1157,11 +1172,18 @@ function Api.healthCheck()
             ["User-Agent"] = Config.USER_AGENT,
         },
         timeout = {5, 10},
-        getRedirectedUrl = function()
-            return Config.getHealthCheckUrl()
+        skipRedirectCache = skip_redir_cache or false,
+        onRedirect = (not is_redir_callback) and function()
+            return function(redir_res)
+                local next_base_url = redir_res and redir_res.real_url_base
+                return Api.healthCheck(baseUrl, skip_redir_cache, next_base_url)
+            end
         end,
     }
 
+    local elapsed = time.to_ms(time.since(start_time)) 
+
+    if is_redir_callback then return http_result end
     if http_result.error then
         logger.dbg("Api.healthCheck - Failed for " .. baseUrl .. ": " .. tostring(http_result.error))
         return { success = false, error = http_result.error }
@@ -1185,35 +1207,60 @@ function Api.healthCheck()
 
     if data.success == 1 then
         logger.info("Api.healthCheck - Success for " .. baseUrl .. " (status: " .. tostring(http_result.status_code) .. ")")
-        return { success = true, url = baseUrl }
+        return { success = true, url = baseUrl, duration = elapsed}
     end
 
     logger.dbg("Api.healthCheck - Invalid response data from " .. baseUrl .. ", success=" .. tostring(data.success))
     return { success = false, error = "Invalid API response" }
 end
 
-function Api.findWorkingBaseUrl()
+
+function Api.findWorkingBaseUrl(seed_urls, progress_callback)
     logger.info("Api.findWorkingBaseUrl - START - Checking SEED_URLS")
-    local original_base_url = Config.getBaseUrl(true)
     
-    local seed_urls = Config.getSeedUrls() or {}
-    local total_urls = #seed_urls
-    for i, seed_url in ipairs(seed_urls) do
-        local clean_url = seed_url:gsub("/$", "")
-        
-        logger.info(string.format("Api.findWorkingBaseUrl - Trying [%d/%d]: %s", i, total_urls, clean_url))
-        Config.setAndValidateBaseUrl(clean_url)
-        local result = Api.healthCheck()
-        if result.success then
-            logger.info(string.format("Api.findWorkingBaseUrl - Found working URL: %s", clean_url))
-            Config.setAndValidateBaseUrl(original_base_url)
-            return { success = true, url = clean_url }
-        end
+    if type(seed_urls) ~= "table" then
+        seed_urls = Config.getSeedUrls() or {}
     end
-    
-    logger.warn("Api.findWorkingBaseUrl - END - No working URL found")
-    Config.setAndValidateBaseUrl(original_base_url)
-    return { success = false, error = T("Could not find a working Z-library server. Please check your internet connection or set the base URL manually.") }
+    local is_fast = type(progress_callback) ~= "function" 
+    if is_fast then progress_callback=function(a, b) end end
+    local first_working_url
+
+    local total_urls = #seed_urls
+    for i, seed_item in ipairs(seed_urls) do
+        local raw_url = type(seed_item) == "table" and seed_item.url or seed_item
+        if type(raw_url) ~= "string" or raw_url == "" then goto continue end
+        
+        local clean_url = raw_url:gsub("/$", "")
+        local source = type(seed_item) == "table" and seed_item.src or "Unknown"
+
+        logger.info(string.format("Api.findWorkingBaseUrl - Trying [%d/%d]: %s", i, total_urls, clean_url))
+        progress_callback("START", {index = i, url = clean_url , src = source})
+        if coroutine.running() then coroutine.yield() end
+
+        local result = Api.healthCheck(clean_url, true)
+
+        progress_callback("END", {
+            index = i,
+            url = clean_url,
+            src = source,
+            success = result.success,
+            duration = result.duration,
+            timestamp = os.time(),
+            error = result.success and nil or (result.error or "Unknown")
+        })
+        if result.success then
+            if not first_working_url then first_working_url = clean_url end
+            logger.info(string.format("Api.findWorkingBaseUrl - Found working URL: %s", clean_url))
+            if is_fast then return { success = true, url = clean_url } end
+        end
+        ::continue::
+    end
+    if first_working_url then
+        return { success = true, url = first_working_url }
+    else
+        logger.warn("Api.findWorkingBaseUrl - END - No working URL found")
+        return { success = false, error = T("Could not find a working Z-library server. Please check your internet connection or set the base URL manually.") }
+    end
 end
 
 function Api.getBookComments(user_id, user_key, book_id)
@@ -1241,7 +1288,7 @@ function Api.getBookComments(user_id, user_key, book_id)
         method = "GET",
         headers = headers,
         timeout = Config.getBookCommentsTimeout(),
-        getRedirectedUrl = function()
+        onRedirect = function()
             return Config.getBookCommentsUrl(book_id)
         end
     }

--- a/zlibrary/api.lua
+++ b/zlibrary/api.lua
@@ -1271,12 +1271,16 @@ function Api.getBookComments(user_id, user_key, book_id)
     }
 end
 
-function Api.fetchDynamicDomains(repo_path)
-    -- local repo = repo_path or "ZlibraryKO/zlibrary.koplugin"
-    -- local url = string.format("https://raw.githubusercontent.com/%s/main/domains.json", repo)
+function Api.fetchDynamicDomains(is_retry)
+     -- Data reference: https://z-lib.gd/eapi/info/domains
+    local cdn_urls = {
+        "https://fastly.jsdelivr.net/gh/ZlibraryKO/zlibrary.koplugin@main/assets/domains.json",
+        "https://cdn.jsdelivr.net/gh/ZlibraryKO/zlibrary.koplugin@main/assets/domains.json",
+        "https://raw.githubusercontent.com/ZlibraryKO/zlibrary.koplugin/main/assets/domains.json"
+    }
 
-    -- test
-    local url = "https://z-lib.gd/eapi/info/domains"
+    local url = cdn_urls[math.random(#cdn_urls)]
+
     logger.info(string.format("Api.fetchDynamicDomains - START - URL: %s", url))
 
     local http_result = Api.makeHttpRequest{
@@ -1291,8 +1295,12 @@ function Api.fetchDynamicDomains(repo_path)
     }
 
     if http_result.error then
-        logger.warn("Api.fetchDynamicDomains - HTTP request error: ", http_result.error)
-        return { success = false, error = http_result.error }
+        logger.warn("Api.fetchDynamicDomains - HTTP request error: ",  tostring(http_result.error))
+        if not is_retry then
+            return Api.fetchDynamicDomains(true)
+        else
+            return { success = false, error = http_result.error }
+        end
     end
 
     if not http_result.body or http_result.body == "" then

--- a/zlibrary/api.lua
+++ b/zlibrary/api.lua
@@ -188,9 +188,11 @@ function Api.makeHttpRequest(options)
     }
 
     logger.dbg(string.format("Zlibrary:Api.makeHttpRequest - Request Params: URL: %s, Method: %s, Timeout: %s", request_params.url, request_params.method, tostring(options.timeout)))
-
-    local req_ok, r_val, r_code, r_headers_tbl, r_status_str = pcall(http.request, request_params)
     
+    local start_time = time.now()
+    local req_ok, r_val, r_code, r_headers_tbl, r_status_str = pcall(http.request, request_params)
+    result.elapsed = time.to_ms(time.since(start_time))
+
     if options.timeout then
         socketutil:reset_timeout()
         logger.dbg("Zlibrary:Api.makeHttpRequest - Reset timeout to default")
@@ -1158,7 +1160,6 @@ function Api.healthCheck(baseUrl, skip_redir_cache, redir_url)
     local is_redir_callback = (type(redir_url) == "string")
     local url = (is_redir_callback and redir_url or baseUrl) .. "/eapi/info/ok"
 
-    local start_time = time.now()
     local http_result = Api.makeHttpRequest{
         url = url,
         method = "GET",
@@ -1176,8 +1177,6 @@ function Api.healthCheck(baseUrl, skip_redir_cache, redir_url)
     }
 
     if is_redir_callback then return http_result end
-    local elapsed = time.to_ms(time.since(start_time)) 
-
     if http_result.error then
         logger.dbg("Api.healthCheck - Failed for " .. baseUrl .. ": " .. tostring(http_result.error))
         return { success = false, error = http_result.error }
@@ -1201,7 +1200,7 @@ function Api.healthCheck(baseUrl, skip_redir_cache, redir_url)
 
     if data.success == 1 then
         logger.info("Api.healthCheck - Success for " .. baseUrl .. " (status: " .. tostring(http_result.status_code) .. ")")
-        return { success = true, url = baseUrl, duration = elapsed}
+        return { success = true, url = baseUrl, elapsed = http_result.elapsed}
     end
 
     logger.dbg("Api.healthCheck - Invalid response data from " .. baseUrl .. ", success=" .. tostring(data.success))
@@ -1238,7 +1237,7 @@ function Api.findWorkingBaseUrl(seed_urls, progress_callback)
             url = clean_url,
             src = source,
             success = result.success,
-            duration = result.duration,
+            elapsed = result.elapsed,
             timestamp = os.time(),
             error = result.success and nil or (result.error or "Unknown")
         })

--- a/zlibrary/api.lua
+++ b/zlibrary/api.lua
@@ -1143,9 +1143,13 @@ function Api.favoriteBook(user_id, user_key, book_stub)
     return { success = true }
 end
 
-function Api.healthCheck(baseUrl)
-    local url = baseUrl .. "/eapi/info/ok"
-
+function Api.healthCheck()
+    local url = Config.getHealthCheckUrl()
+    if not url then
+        logger.warn("Api.healthCheck - Base URL not configured")
+        return { error = T("Z-library server URL not configured.") }
+    end
+    local baseUrl = Config.getBaseUrl(true)
     local http_result = Api.makeHttpRequest{
         url = url,
         method = "GET",
@@ -1153,7 +1157,9 @@ function Api.healthCheck(baseUrl)
             ["User-Agent"] = Config.USER_AGENT,
         },
         timeout = {5, 10},
-        redirect = true,
+        getRedirectedUrl = function()
+            return Config.getHealthCheckUrl()
+        end,
     }
 
     if http_result.error then
@@ -1188,6 +1194,7 @@ end
 
 function Api.findWorkingBaseUrl()
     logger.info("Api.findWorkingBaseUrl - START - Checking SEED_URLS")
+    local original_base_url = Config.getBaseUrl(true)
     
     local seed_urls = Config.getSeedUrls() or {}
     local total_urls = #seed_urls
@@ -1195,15 +1202,17 @@ function Api.findWorkingBaseUrl()
         local clean_url = seed_url:gsub("/$", "")
         
         logger.info(string.format("Api.findWorkingBaseUrl - Trying [%d/%d]: %s", i, total_urls, clean_url))
-        
-        local result = Api.healthCheck(clean_url)
+        Config.setAndValidateBaseUrl(clean_url)
+        local result = Api.healthCheck()
         if result.success then
             logger.info(string.format("Api.findWorkingBaseUrl - Found working URL: %s", clean_url))
+            Config.setAndValidateBaseUrl(original_base_url)
             return { success = true, url = clean_url }
         end
     end
     
     logger.warn("Api.findWorkingBaseUrl - END - No working URL found")
+    Config.setAndValidateBaseUrl(original_base_url)
     return { success = false, error = T("Could not find a working Z-library server. Please check your internet connection or set the base URL manually.") }
 end
 

--- a/zlibrary/api.lua
+++ b/zlibrary/api.lua
@@ -1190,10 +1190,11 @@ function Api.findWorkingBaseUrl()
     logger.info("Api.findWorkingBaseUrl - START - Checking SEED_URLS")
     
     local seed_urls = Config.getSeedUrls() or {}
+    local total_urls = #seed_urls
     for i, seed_url in ipairs(seed_urls) do
         local clean_url = seed_url:gsub("/$", "")
         
-        logger.info(string.format("Api.findWorkingBaseUrl - Trying [%d/%d]: %s", i, #Config.SEED_URLS, clean_url))
+        logger.info(string.format("Api.findWorkingBaseUrl - Trying [%d/%d]: %s", i, total_urls, clean_url))
         
         local result = Api.healthCheck(clean_url)
         if result.success then

--- a/zlibrary/api.lua
+++ b/zlibrary/api.lua
@@ -1179,81 +1179,32 @@ function Api.healthCheck(baseUrl, skip_redir_cache, redir_url)
     if is_redir_callback then return http_result end
     if http_result.error then
         logger.dbg("Api.healthCheck - Failed for " .. baseUrl .. ": " .. tostring(http_result.error))
-        return { success = false, error = http_result.error }
+        return { success = false, error = http_result.error, elapsed = http_result.elapsed}
     end
 
     if not http_result.status_code or http_result.status_code < 200 or http_result.status_code >= 300 then
         logger.dbg("Api.healthCheck - Invalid status code " .. tostring(http_result.status_code) .. " for " .. baseUrl)
-        return { success = false, error = "Invalid status code: " .. tostring(http_result.status_code) }
+        return { success = false, elapsed = http_result.elapsed, error = "Invalid status code: " .. tostring(http_result.status_code) }
     end
 
     if not http_result.body or http_result.body == "" then
         logger.dbg("Api.healthCheck - No response body from " .. baseUrl)
-        return { success = false, error = "No response body" }
+        return { success = false, error = "No response body", elapsed = http_result.elapsed}
     end
 
     local success_parse, data = pcall(json.decode, http_result.body, json.decode.simple)
     if not success_parse or not data then
         logger.dbg("Api.healthCheck - Failed to parse JSON from " .. baseUrl)
-        return { success = false, error = "Invalid JSON response" }
+        return { success = false, error = "Invalid JSON response", elapsed = http_result.elapsed}
     end
 
     if data.success == 1 then
         logger.info("Api.healthCheck - Success for " .. baseUrl .. " (status: " .. tostring(http_result.status_code) .. ")")
-        return { success = true, url = baseUrl, elapsed = http_result.elapsed}
+        return { success = true, url = baseUrl, elapsed = http_result.elapsed, real_url= redir_url}
     end
 
     logger.dbg("Api.healthCheck - Invalid response data from " .. baseUrl .. ", success=" .. tostring(data.success))
-    return { success = false, error = "Invalid API response" }
-end
-
-
-function Api.findWorkingBaseUrl(seed_urls, progress_callback)
-    logger.info("Api.findWorkingBaseUrl - START - Checking SEED_URLS")
-    
-    if type(seed_urls) ~= "table" then
-        seed_urls = Config.getSeedUrls() or {}
-    end
-    local find_first_match = type(progress_callback) ~= "function" 
-    if find_first_match then progress_callback=function(a, b) end end
-    local first_working_url
-
-    local total_urls = #seed_urls
-    for i, seed_item in ipairs(seed_urls) do
-        local raw_url = type(seed_item) == "table" and seed_item.url or seed_item
-        if type(raw_url) ~= "string" or raw_url == "" then goto continue end
-        
-        local clean_url = raw_url:gsub("/$", "")
-        local source = type(seed_item) == "table" and seed_item.src or "Unknown"
-
-        logger.info(string.format("Api.findWorkingBaseUrl - Trying [%d/%d]: %s", i, total_urls, clean_url))
-        progress_callback("START", {index = i, url = clean_url , src = source})
-        if coroutine.running() then coroutine.yield() end
-
-        local result = Api.healthCheck(clean_url, true)
-
-        progress_callback("END", {
-            index = i,
-            url = clean_url,
-            src = source,
-            success = result.success,
-            elapsed = result.elapsed,
-            timestamp = os.time(),
-            error = result.success and nil or (result.error or "Unknown")
-        })
-        if result.success then
-            if not first_working_url then first_working_url = clean_url end
-            logger.info(string.format("Api.findWorkingBaseUrl - Found working URL: %s", clean_url))
-            if find_first_match then return { success = true, url = clean_url } end
-        end
-        ::continue::
-    end
-    if first_working_url then
-        return { success = true, url = first_working_url }
-    else
-        logger.warn("Api.findWorkingBaseUrl - END - No working URL found")
-        return { success = false, error = T("Could not find a working Z-library server. Please check your internet connection or set the base URL manually.") }
-    end
+    return { success = false, error = "Invalid API response", elapsed = http_result.elapsed}
 end
 
 function Api.getBookComments(user_id, user_key, book_id)

--- a/zlibrary/async_helper.lua
+++ b/zlibrary/async_helper.lua
@@ -1,8 +1,201 @@
 local UIManager = require("ui/uimanager")
+local ffiUtil = require("ffi/util")
+local Device = require("device")
+local Trapper = require("ui/trapper")
 local coroutine = require("coroutine")
 local logger = require("logger")
 
-local AsyncHelper = {}
+local Channel = {}
+Channel.__index = Channel
+
+function Channel:new(name, max_workers, shared_cache)
+    local obj = setmetatable({}, self)
+    obj.name = name
+    obj.max_workers = max_workers or 1
+    obj.active_workers = 0
+    obj.session = 0
+    obj.queue = {}
+    obj.cache = shared_cache
+    return obj
+end
+
+-- NetworkMgr:isConnected() not Work in task
+function Channel:pushTask(task_func, callback, opts)
+    opts = opts or {}
+    local cache_key = opts.cache_key
+    if cache_key and self.cache[cache_key] then
+        UIManager:nextTick(function()
+            if opts.on_start then pcall(opts.on_start) end
+            pcall(callback, true, self.cache[cache_key])
+        end)
+        return
+    end
+    table.insert(self.queue, {
+        func = task_func,
+        args = opts.args,
+        on_start = opts.on_start,
+        timeout = opts.timeout,
+        callback = callback,
+        cache_key = cache_key,
+        returns_string = opts.returns_string or false,
+        session = self.session
+    })
+    if self.active_workers < self.max_workers then
+        self:_processNext()
+    end
+end
+
+function Channel:_processNext()
+    if #self.queue == 0 then return end
+    self.active_workers = self.active_workers + 1
+
+    local task = table.remove(self.queue, 1)
+    local execute_func
+    if task.args and type(task.args) == "table" then
+        execute_func = function() return task.func(unpack(task.args)) end
+    else
+        execute_func = task.func
+    end
+
+    if type(task.on_start) == "function" then pcall(task.on_start) end
+    
+    local buffer = require("string.buffer")
+    local timeout = task.timeout or 180
+
+    Trapper:wrap(function()
+        pcall(function() Device:enableCPUCores(2) end)
+        logger.dbg("Channel:_processNext - START")
+        
+        local start_time = os.time()
+        local pid, parent_read_fd = nil, nil
+        local poll_count = 0
+        local function deliver_result(ok, r1, r2)
+            if parent_read_fd then
+                pcall(ffiUtil.readAllFromFD, parent_read_fd)
+                parent_read_fd = nil
+            end
+            local status, err = pcall(function() Device:enableCPUCores(1) end)
+            if not status then
+                logger.err('Channel:_processNext - Device.enableCPUCores err', tostring(err))
+            end
+            logger.dbg("Channel:_processNext - END")
+            local completed, result = ok, r1
+            if task.session == self.session then
+                if completed and result ~= nil then
+                    if task.cache_key then self.cache[task.cache_key] = result end
+                    pcall(task.callback, true, result)
+                else
+                    pcall(task.callback, false, nil)
+                end
+            else
+                logger.dbg("Channel: Dropped stale task for:", self.name)
+            end
+            self.active_workers = self.active_workers - 1
+            UIManager:nextTick(function() self:_processNext() end)
+        end
+        pid, parent_read_fd = ffiUtil.runInSubProcess(function(_pid, child_write_fd)
+            local job_ok, r1, r2 = pcall(execute_func)
+            local ret_tbl = { ok = job_ok, r1 = r1, r2 = r2 }
+            -- NOTE: LuaJIT's serializer currently doesn't support:
+            --       functions, coroutines, non-numerical FFI cdata & full userdata.
+            local output_str = ""
+            local enc_ok, str = pcall(buffer.encode, ret_tbl)
+            if enc_ok and str then
+                output_str = str
+            else
+                logger.warn("Channel:_processNext - serialization failed:", str or "unknown error")
+                ret_tbl = { ok = false, r1 = "serialization_error", r2 = tostring(str)}
+                output_str = buffer.encode(ret_tbl) or ""
+            end
+            ffiUtil.writeToFD(child_write_fd, output_str, true)
+        end, true)
+        if not pid then
+            logger.dbg("Channel:_processNext - background task failed to start")
+            deliver_result(false, "start_failed", parent_read_fd)
+            return
+        end
+        local function poll()
+            poll_count = poll_count + 1
+            if timeout and os.difftime(os.time(), start_time) >= timeout then
+                logger.dbg("Channel:_processNext - timeout reached, killing subprocess")
+                ffiUtil.terminateSubProcess(pid)
+                UIManager:scheduleIn(0.5, function()
+                    deliver_result(false, "timeout")
+                end)
+                return
+            end
+            local subprocess_done = ffiUtil.isSubProcessDone(pid)
+            local stuff_to_read = parent_read_fd and ffiUtil.getNonBlockingReadSize(parent_read_fd) ~= 0
+            
+            if subprocess_done or stuff_to_read then
+                local ok, r1, r2 = false, nil, nil
+                if parent_read_fd then
+                    local ret_str = ffiUtil.readAllFromFD(parent_read_fd) or ""
+                    local dec_ok, ret_tbl = pcall(buffer.decode, ret_str)
+
+                    if dec_ok and ret_tbl and type(ret_tbl) == "table" then
+                        ok, r1, r2 = ret_tbl.ok, ret_tbl.r1, ret_tbl.r2
+                    else
+                        logger.warn(string.format("Channel:_processNext - malformed data (len: %d)", #ret_str))
+                        ok, r1, r2 = false, "decode_error", nil
+                    end
+                    ret_str = nil
+                    parent_read_fd = nil
+                end
+                
+                logger.dbg("Channel:_processNext - background task completed")
+                deliver_result(ok, r1, r2)
+            else
+                local next_delay = (poll_count <= 5) and 0.02 or 0.2
+                UIManager:scheduleIn(next_delay, poll)
+            end
+        end
+        poll()
+    end)
+end
+
+function Channel:clearTasks()
+    self.queue = {}
+    self.session = self.session + 1
+    logger.dbg("Channel: Tasks cleared. New session for:", self.name)
+end
+
+
+local AsyncHelper = {
+    cache = {},
+    channels = {}
+}
+
+function AsyncHelper:createChannel(name, max_workers)
+    if not self.channels[name] then
+        self.channels[name] = Channel:new(name, max_workers, self.cache)
+        logger.dbg(string.format("AsyncHelper: Created channel '%s' (max_workers=%d)", name, max_workers or 1))
+    end
+    return self.channels[name]
+end
+
+function AsyncHelper:getChannel(name)
+    return self.channels[name] or self:createChannel(name, 1)
+end
+
+function AsyncHelper:clearCache()
+    self.cache = {}
+    logger.dbg("AsyncHelper: Global cache cleared.")
+end
+
+function AsyncHelper.delay(seconds, func)
+    local pending = true
+    UIManager:scheduleIn(seconds, function()
+        pending = false
+        func()
+    end)
+    return function()
+        if pending then
+            pending = false
+            UIManager:unschedule(func)
+        end
+    end
+end
 
 function AsyncHelper.run(task_func, on_success, on_error, loading_msg_widget_to_close)
     logger.dbg("AsyncHelper.run - START")

--- a/zlibrary/config.lua
+++ b/zlibrary/config.lua
@@ -216,7 +216,7 @@ function Config.getSeedUrls()
     local clean_base = (type(base) == "string" and base ~= "") and base:gsub("/$", "") or nil
     if clean_base then seen[clean_base] = true end
 
-    local function processAndMerge(source_urls)
+    local function processAndMerge(source_urls , src_name)
         if type(source_urls) ~= "table" or #source_urls == 0 then return end
         local temp_urls = {}
         
@@ -224,12 +224,12 @@ function Config.getSeedUrls()
         for _, url in ipairs(source_urls) do
             if type(url) == "string" and url ~= "" then
                 local clean_url = url:gsub("/$", "")
-                if not clean_url :match("^https?://") then
-                        clean_url  = "https://" .. clean_url 
+                if not clean_url:match("^https?://") then
+                    clean_url  = "https://" .. clean_url 
                 end
                 if not seen[clean_url] then
                     seen[clean_url] = true
-                    table.insert(temp_urls, clean_url)
+                    table.insert(temp_urls, {url = clean_url, src = src_name})
                 end
             end
         end
@@ -238,18 +238,18 @@ function Config.getSeedUrls()
             local j = math.random(i)
             temp_urls[i], temp_urls[j] = temp_urls[j], temp_urls[i]
         end
-        for _, url in ipairs(temp_urls) do
-            table.insert(new_seed_urls, url)
+        for _, item in ipairs(temp_urls) do
+            table.insert(new_seed_urls, item)
         end
     end
 
     -- User-defined  > Hardcoded > Dynamic
     local cred_file_path = Config._plugin_path .. Config.CREDENTIALS_FILENAME
     local creds = LuaSettings:open(cred_file_path)
-    processAndMerge(creds and creds:readSetting("seedUrls"))
-    processAndMerge(Config.SEED_URLS)
+    processAndMerge(creds and creds:readSetting("seedUrls"), "U")
+    processAndMerge(Config.SEED_URLS, "C")
     local domains_cache = Cache:new{ name = "_domains_cache" }
-    processAndMerge(domains_cache:get("domains", 86400))
+    processAndMerge(domains_cache:get("domains", 86400), "D")
     
     return new_seed_urls
 end
@@ -288,12 +288,6 @@ function Config.getSearchUrl(query)
     local base = Config.getBaseUrl()
     if not base then return nil end
     return base .. "/eapi/book/search"
-end
-
-function Config.getHealthCheckUrl()
-    local base = Config.getBaseUrl()
-    if not base then return nil end
-    return base .. "/eapi/info/ok"
 end
 
 function Config.getBookUrl(href)

--- a/zlibrary/config.lua
+++ b/zlibrary/config.lua
@@ -168,7 +168,7 @@ end
 
 -- Singleton lazy instance to avoid recreating Cache on every call
 local _config_runtime_cache
-local function _getConfigRuntimeCache()
+function Config.getConfigRuntimeCache()
     if not _config_runtime_cache then
         _config_runtime_cache = Cache:new{ name = "_runtime_cache" }
     end
@@ -176,12 +176,12 @@ local function _getConfigRuntimeCache()
 end
 
 function Config.getCacheRealUrl()
-    local api_real_url = _getConfigRuntimeCache():get("api_real_url", 600)
+    local api_real_url = Config.getConfigRuntimeCache():get("api_real_url", 600)
     return api_real_url and api_real_url[1]
 end
 
 function Config.clearCacheRealUrl()
-    return _getConfigRuntimeCache():remove("api_real_url")
+    return Config.getConfigRuntimeCache():remove("api_real_url")
 end
 
 function Config.setCacheRealUrl(original_url, real_url)
@@ -198,7 +198,7 @@ function Config.setCacheRealUrl(original_url, real_url)
         real_url = string.sub(real_url, 1, -2)
     end
     
-    return _getConfigRuntimeCache():insert("api_real_url", {real_url})
+    return Config.getConfigRuntimeCache():insert("api_real_url", {real_url})
 end
 
 function Config.getBaseUrl(is_original)
@@ -224,6 +224,9 @@ function Config.getSeedUrls()
         for _, url in ipairs(source_urls) do
             if type(url) == "string" and url ~= "" then
                 local clean_url = url:gsub("/$", "")
+                if not clean_url :match("^https?://") then
+                        clean_url  = "https://" .. clean_url 
+                end
                 if not seen[clean_url] then
                     seen[clean_url] = true
                     table.insert(temp_urls, clean_url)
@@ -240,14 +243,14 @@ function Config.getSeedUrls()
         end
     end
 
-    -- User-defined > Dynamic > Hardcoded
+    -- User-defined  > Hardcoded > Dynamic
     local cred_file_path = Config._plugin_path .. Config.CREDENTIALS_FILENAME
     local creds = LuaSettings:open(cred_file_path)
     processAndMerge(creds and creds:readSetting("seedUrls"))
+    processAndMerge(Config.SEED_URLS)
     local domains_cache = Cache:new{ name = "_domains_cache" }
     processAndMerge(domains_cache:get("domains", 86400))
-    processAndMerge(Config.SEED_URLS)
-
+    
     return new_seed_urls
 end
 

--- a/zlibrary/config.lua
+++ b/zlibrary/config.lua
@@ -197,7 +197,7 @@ function Config.setCacheRealUrl(original_url, real_url)
     if string.sub(real_url, -1) == "/" then
         real_url = string.sub(real_url, 1, -2)
     end
-    
+
     return Config.getConfigRuntimeCache():insert("api_real_url", {real_url})
 end
 
@@ -288,6 +288,12 @@ function Config.getSearchUrl(query)
     local base = Config.getBaseUrl()
     if not base then return nil end
     return base .. "/eapi/book/search"
+end
+
+function Config.getHealthCheckUrl()
+    local base = Config.getBaseUrl()
+    if not base then return nil end
+    return base .. "/eapi/info/ok"
 end
 
 function Config.getBookUrl(href)

--- a/zlibrary/config.lua
+++ b/zlibrary/config.lua
@@ -244,9 +244,8 @@ function Config.getSeedUrls()
     end
 
     -- User-defined  > Hardcoded > Dynamic
-    local cred_file_path = Config._plugin_path .. Config.CREDENTIALS_FILENAME
-    local creds = LuaSettings:open(cred_file_path)
-    processAndMerge(creds and creds:readSetting("seedUrls"), "U")
+    local settings =  _getLuaSettings()
+    processAndMerge(settings and settings:readSetting("seedUrls"), "U")
     processAndMerge(Config.SEED_URLS, "C")
     local domains_cache = Cache:new{ name = "_domains_cache" }
     processAndMerge(domains_cache:get("domains", 86400), "D")

--- a/zlibrary/config.lua
+++ b/zlibrary/config.lua
@@ -208,6 +208,25 @@ function Config.getBaseUrl(is_original)
     return configured_url
 end
 
+function Config.getSeedUrls()
+    local base = Config.getBaseUrl()
+    local clean_base = (type(base) == "string" and base ~= "") and base:gsub("/$", "") or nil
+
+    local urls = {}
+    for _, url in ipairs(Config.SEED_URLS) do
+        if type(url) == "string" and url ~= "" then
+            local clean_url = url:gsub("/$", "")
+            if clean_url ~= clean_base then table.insert(urls, clean_url) end
+        end
+    end
+    -- Shuffle
+    for i = #urls, 2, -1 do
+        local j = math.random(i)
+        urls[i], urls[j] = urls[j], urls[i]
+    end
+    return urls
+end
+
 function Config.setAndValidateBaseUrl(url_string)
     if not url_string or url_string == "" then
         return false, "Error: URL cannot be empty."

--- a/zlibrary/config.lua
+++ b/zlibrary/config.lua
@@ -43,6 +43,7 @@ Config.TIMEOUT_COVER = { 5, 15 }        -- Cover image operations
 Config.TIMEOUT_BOOK_COMMENTS = { 10, 15 } -- Comments operations
 
 function Config.loadCredentialsFromFile(plugin_path)
+    Config._plugin_path = plugin_path
     local cred_file_path = plugin_path .. Config.CREDENTIALS_FILENAME
     local creds = LuaSettings:open(cred_file_path)
     if not creds.data or not next(creds.data) then
@@ -209,22 +210,45 @@ function Config.getBaseUrl(is_original)
 end
 
 function Config.getSeedUrls()
+    local new_seed_urls, seen = {}, {}
+
     local base = Config.getBaseUrl()
     local clean_base = (type(base) == "string" and base ~= "") and base:gsub("/$", "") or nil
+    if clean_base then seen[clean_base] = true end
 
-    local urls = {}
-    for _, url in ipairs(Config.SEED_URLS) do
-        if type(url) == "string" and url ~= "" then
-            local clean_url = url:gsub("/$", "")
-            if clean_url ~= clean_base then table.insert(urls, clean_url) end
+    local function processAndMerge(source_urls)
+        if type(source_urls) ~= "table" or #source_urls == 0 then return end
+        local temp_urls = {}
+        
+        -- clean & deduplicate
+        for _, url in ipairs(source_urls) do
+            if type(url) == "string" and url ~= "" then
+                local clean_url = url:gsub("/$", "")
+                if not seen[clean_url] then
+                    seen[clean_url] = true
+                    table.insert(temp_urls, clean_url)
+                end
+            end
+        end
+        -- Shuffle
+        for i = #temp_urls, 2, -1 do
+            local j = math.random(i)
+            temp_urls[i], temp_urls[j] = temp_urls[j], temp_urls[i]
+        end
+        for _, url in ipairs(temp_urls) do
+            table.insert(new_seed_urls, url)
         end
     end
-    -- Shuffle
-    for i = #urls, 2, -1 do
-        local j = math.random(i)
-        urls[i], urls[j] = urls[j], urls[i]
-    end
-    return urls
+
+    -- User-defined > Dynamic > Hardcoded
+    local cred_file_path = Config._plugin_path .. Config.CREDENTIALS_FILENAME
+    local creds = LuaSettings:open(cred_file_path)
+    processAndMerge(creds and creds:readSetting("seedUrls"))
+    local domains_cache = Cache:new{ name = "_domains_cache" }
+    processAndMerge(domains_cache:get("domains", 86400))
+    processAndMerge(Config.SEED_URLS)
+
+    return new_seed_urls
 end
 
 function Config.setAndValidateBaseUrl(url_string)

--- a/zlibrary/config.lua
+++ b/zlibrary/config.lua
@@ -5,7 +5,10 @@ local LuaSettings = require("luasettings")
 local T = require("zlibrary.gettext")
 local Cache = require("zlibrary.cache")
 
-local Config = {}
+local Config = {
+    _lua_settings = nil,
+    _runtime_cache = nil,
+}
 
 Config.SETTINGS_BASE_URL_KEY = "zlibrary_base_url"
 Config.SETTINGS_USERNAME_KEY = "zlibrary_username"
@@ -146,33 +149,31 @@ Config.SEED_URLS = { -- List of known Z-library base URLs extracted from the And
     "https://z-lib.gl/"
 }
 
-local _lua_settings
 local function _getLuaSettings()
-    if not _lua_settings then
+    if not Config._lua_settings then
         local settings_file = DataStorage:getSettingsDir() .. "/zlibrary.lua"
-        _lua_settings = LuaSettings:open(settings_file)
+        Config._lua_settings = LuaSettings:open(settings_file)
 
         -- Check if data migration from old settings is needed
-        if not _lua_settings:readSetting(Config.SETTINGS_BASE_URL_KEY) and (G_reader_settings and G_reader_settings:readSetting(Config.SETTINGS_BASE_URL_KEY)) then
+        if not Config._lua_settings:readSetting(Config.SETTINGS_BASE_URL_KEY) and (G_reader_settings and G_reader_settings:readSetting(Config.SETTINGS_BASE_URL_KEY)) then
              for key, value in pairs(G_reader_settings.data) do
                 if type(key) == "string" and (key:match("^zlib_") or key:match("^zlibrary_")) then
-                    _lua_settings:saveSetting(key, value)
+                    Config._lua_settings:saveSetting(key, value)
                     G_reader_settings:delSetting(key)
                 end
             end
-            _lua_settings:flush()
+            Config._lua_settings:flush()
         end
     end
-    return _lua_settings
+    return Config._lua_settings
 end
 
 -- Singleton lazy instance to avoid recreating Cache on every call
-local _config_runtime_cache
 function Config.getConfigRuntimeCache()
-    if not _config_runtime_cache then
-        _config_runtime_cache = Cache:new{ name = "_runtime_cache" }
+    if not Config._runtime_cache then
+        Config._runtime_cache = Cache:new{ name = "_runtime_cache" }
     end
-    return _config_runtime_cache
+    return Config._runtime_cache
 end
 
 function Config.getCacheRealUrl()
@@ -204,7 +205,8 @@ end
 function Config.getBaseUrl(is_original)
     local configured_url = (not is_original and Config.getCacheRealUrl()) or Config.getSetting(Config.SETTINGS_BASE_URL_KEY)
     if configured_url == nil or configured_url == "" then
-        return nil
+        -- default
+        configured_url = (Config.SEED_URLS and #Config.SEED_URLS > 0) and Config.SEED_URLS[1] or nil
     end
     return configured_url
 end

--- a/zlibrary/multisearch_dialog.lua
+++ b/zlibrary/multisearch_dialog.lua
@@ -78,7 +78,7 @@ function SearchDialog:init()
         with_bottom_line = true,
         left_icon = "appbar.search",
         left_icon_size_ratio = 0.9,
-        left_icon_allow_flash = true,
+        right_icon_size_ratio = 0.9,
         left_icon_tap_callback = function()
             self.on_search_callback(self.def_search_input)
         end,

--- a/zlibrary/ui.lua
+++ b/zlibrary/ui.lua
@@ -896,7 +896,18 @@ function Ui.showRetryErrorDialog(err_msg, operation_name, retry_callback, cancel
                         Ui.closeMessage(loading_msg_to_close)
                     end
                     cancel_callback(err_msg)
-                end
+                end,
+                other_buttons_first = is_timeout and true or nil,
+                other_buttons = is_timeout and {{{ 
+                    text = string.format("%s&%s",T("Auto-discover base URL"), T("Retry")), 
+                    callback = function()  
+                        if loading_msg_to_close then  
+                            Ui.closeMessage(loading_msg_to_close)  
+                        end  
+                        local result = _plugin_instance:autoDiscoverAndSetBaseUrl()
+                        if result and result.success then retry_callback() end
+                    end  
+                }}} or nil,  
             })
         else
             if loading_msg_to_close then

--- a/zlibrary/ui.lua
+++ b/zlibrary/ui.lua
@@ -904,8 +904,7 @@ function Ui.showRetryErrorDialog(err_msg, operation_name, retry_callback, cancel
                         if loading_msg_to_close then  
                             Ui.closeMessage(loading_msg_to_close)  
                         end  
-                        local result = _plugin_instance:autoDiscoverAndSetBaseUrl()
-                        if result and result.success then retry_callback() end
+                        _plugin_instance:autoDiscoverAndSetBaseUrl(nil, retry_callback)
                     end  
                 }}} or nil,  
             })

--- a/zlibrary/ui.lua
+++ b/zlibrary/ui.lua
@@ -6,6 +6,7 @@ local T = require("zlibrary.gettext")
 local DownloadMgr = require("ui/downloadmgr")
 local InputDialog = require("ui/widget/inputdialog")
 local Menu = require("zlibrary.menu")
+local Device = require("device")
 local util = require("util")
 local logger = require("logger")
 local Config = require("zlibrary.config")
@@ -212,6 +213,8 @@ local function _showMultiSelectionDialog(parent_ui, title, setting_key, options_
         item_table = menu_items,
         parent = parent_ui,
         show_captions = true,
+        is_popout = false,
+        title_bar_fm_style = true,
         onClose = function()
             local ok, err = pcall(function()
                 local new_selected_values = {}
@@ -326,10 +329,16 @@ end
 
 function Ui.showSearchDialog(parent_zlibrary, def_input)
     -- save last search input
-    if Ui._last_search_input and not def_input then
+    if not def_input then
         def_input = Ui._last_search_input
+        if not def_input and Device:hasClipboard() then
+            local clip_text = Device.input.getClipboardText()
+            if type(clip_text) == "string" and #clip_text < 80 then
+                def_input = clip_text
+            end
+        end
     end
-
+  
     local dialog
     local search_order_name = Config.getSearchOrderName()
     
@@ -369,6 +378,7 @@ function Ui.showSearchDialog(parent_zlibrary, def_input)
             _closeAndUntrackDialog(dialog)
 
             if not query or not query:match("%S") then
+                Ui._last_search_input = nil
                 Ui.showErrorMessage(T("Please enter a search term."))
                 return
             end
@@ -491,6 +501,8 @@ function Ui.showBookDetails(parent_zlibrary, book, clear_cache_callback)
         item_table = {},
         parent = parent_zlibrary.ui,
         show_captions = true,
+        is_popout = false,
+        title_bar_fm_style = true,
         multilines_show_more_text = true
     }
 
@@ -1026,6 +1038,7 @@ function Ui.showTimeoutConfigDialog(parent_ui, timeout_name, timeout_key, getter
         item_table = dialog_items,
         parent = parent_ui,
         show_captions = true,
+        is_popout = false,
     }
     
     local original_onClose = dialog_menu.onClose
@@ -1138,6 +1151,7 @@ function Ui.showAllTimeoutConfigDialog(parent_ui)
         },
         {
             text = T("Reset all timeouts to defaults"),
+            mandatory = "\u{25B7}",
             callback = function()
                 if _plugin_instance and _plugin_instance.dialog_manager then
                     _plugin_instance.dialog_manager:showConfirmDialog({
@@ -1167,6 +1181,8 @@ function Ui.showAllTimeoutConfigDialog(parent_ui)
         item_table = timeout_items,
         parent = parent_ui,
         show_captions = true,
+        is_popout = false,
+        title_bar_fm_style = true,
     }
     _showAndTrackDialog(main_menu)
 end
@@ -1279,7 +1295,7 @@ function Ui.showUrlCheckProgress(parent_zlibrary, menu_items)
         is_borderless = true,
         show_captions = true,
         title_bar_fm_style = true,
-        multilines_show_more_text = true,
+        single_line = true,
     }
     _showAndTrackDialog(menu)
     return menu

--- a/zlibrary/ui.lua
+++ b/zlibrary/ui.lua
@@ -1269,4 +1269,20 @@ function Ui.showCommentsDialog(parent_zlibrary, book_comments)
     _showAndTrackDialog(comments_popup)
 end
 
+function Ui.showUrlCheckProgress(parent_zlibrary, menu_items)
+    if type(menu_items) ~= "table" then menu_items = {} end
+    local menu = Menu:new{
+        title = T("Auto-discover base URL"),
+        item_table = menu_items,
+        show_parent = parent_zlibrary.ui,
+        is_popout = false,
+        is_borderless = true,
+        show_captions = true,
+        title_bar_fm_style = true,
+        multilines_show_more_text = true,
+    }
+    _showAndTrackDialog(menu)
+    return menu
+end
+
 return Ui

--- a/zlibrary/ui.lua
+++ b/zlibrary/ui.lua
@@ -276,11 +276,12 @@ function Ui.showOrdersSelectionDialog(parent_ui, ok_callback)
     _showRadioSelectionDialog(parent_ui, T("Select search order"), Config.SETTINGS_SEARCH_ORDERS_KEY, Config.SUPPORTED_ORDERS, ok_callback)
 end
 
-function Ui.showGenericInputDialog(title, setting_key, current_value_or_default, is_password, validate_and_save_callback)
+function Ui.showGenericInputDialog(title, setting_key, current_value_or_default, is_password, validate_and_save_callback, description)
     local dialog
 
     dialog = InputDialog:new{
         title = title,
+        description = description,
         input = current_value_or_default or "",
         text_type = is_password and "password" or nil,
         buttons = {{
@@ -1271,7 +1272,7 @@ end
 function Ui.showUrlCheckProgress(parent_zlibrary, menu_items)
     if type(menu_items) ~= "table" then menu_items = {} end
     local menu = Menu:new{
-        title = T("Auto-discover base URL"),
+        title = T("Set base URL"),
         item_table = menu_items,
         show_parent = parent_zlibrary.ui,
         is_popout = false,

--- a/zlibrary/ui.lua
+++ b/zlibrary/ui.lua
@@ -325,6 +325,7 @@ function Ui.showGenericInputDialog(title, setting_key, current_value_or_default,
     }
     _showAndTrackDialog(dialog)
     dialog:onShowKeyboard()
+    return dialog
 end
 
 function Ui.showSearchDialog(parent_zlibrary, def_input)
@@ -1285,7 +1286,7 @@ function Ui.showCommentsDialog(parent_zlibrary, book_comments)
     _showAndTrackDialog(comments_popup)
 end
 
-function Ui.showUrlCheckProgress(parent_zlibrary, menu_items)
+function Ui.showUrlCheckProgress(parent_zlibrary, menu_items, close_callback)
     if type(menu_items) ~= "table" then menu_items = {} end
     local menu = Menu:new{
         title = T("Set base URL"),
@@ -1297,6 +1298,10 @@ function Ui.showUrlCheckProgress(parent_zlibrary, menu_items)
         title_bar_fm_style = true,
         single_line = true,
     }
+    function menu:onCloseWidget() 
+        if type(close_callback) == "" then close_callback() end
+        Menu.onCloseWidget(self)
+    end
     _showAndTrackDialog(menu)
     return menu
 end

--- a/zlibrary_credentials.lua
+++ b/zlibrary_credentials.lua
@@ -6,5 +6,4 @@ return {
     -- baseUrl = "https://your.zlibrary.domain.com",
     -- email = "your_email",
     -- password = "your_password",
-    -- seedUrls = {},
 }

--- a/zlibrary_credentials.lua
+++ b/zlibrary_credentials.lua
@@ -6,4 +6,5 @@ return {
     -- baseUrl = "https://your.zlibrary.domain.com",
     -- email = "your_email",
     -- password = "your_password",
+    -- seedUrls = {},
 }


### PR DESCRIPTION
> I do like the idea of giving users more control though. One approach could be to keep the hardcoded list as is, cache domains from the /domains endpoint and allow users to define their own preferred domains in a file. Then we have the best of both worlds.
>
> So user defined should be top priority, then the dynamic urls and last the (rest of the) hardcoded list.
>
> We should keep user configuration in .lua files and but remote domain lists can be stored in json. It's practical to add this to the credentials file, one caveat would be that we're mixing sensitive data and non-sensitive config. But I don't think that would be a big problem.
>
> I also briefly considered a UI to show which mirrors are up and maybe even rank them by latency, but that feels like overkill for now.

Since official domains are frequently blocked in some regions, finding a currently available base URL is the biggest obstacle to freely using Z-Library. It's also necessary to avoid the risk of fraudulent websites, such as: (`zlibrary.to`, `zlibrary.st`, `z-lib.is`, `z-lib.io`, `z-lib.id`). **Auto-discover base URL** is very useful, and this PR enhances it. A continuously maintained trusted dynamic domain can solve many problems, and a visual interface makes it even easier to use.

- **Multi-source domain discovery**: Supports aggregating sources from hardcoded list, dynamic API endpoints, and ~~user-defined files~~. Priority strategy: ~~**User-defined [U]~~ > Hardcoded [C] > Dynamic [D]**. Supports deduplication and randomization.
- **Added Auto-discover base URL & Retry button** to `RetryErrorDialog` (#133)
- **Api.healthCheck now supports 302 redirects** (#94), adapting to redirect logic of some mirror sites, and records request duration
- **Added a visual connection test widget** with interactive testing interface: supports manual Base URL configuration even when offline
- **~~TODO: Concurrent availability testing.~~ Concurrent testing now supported

<br><br>
<img width="33%" alt="demo" src="https://github.com/user-attachments/assets/1f2db7b9-f986-4621-a3c9-d3268266818f" />