### PR TITLE
Stop the release workflow's po check from writing messages.mo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
                     echo "Failed to update $po_file!"
                 fi
                 echo "Checking and compiling $po_file ..."
-                msgfmt --check-format --verbose "$po_file" \
+                msgfmt --check-format --verbose -o /dev/null "$po_file" \
                   && msgfmt "$po_file" -o "${po_file%.po}.mo" \
                   && echo "Compiled successfully: ${po_file%.po}.mo" \
                   || echo "Errors in $po_file"


### PR DESCRIPTION
msgfmt writes its default output file, ./messages.mo, when no -o is given. The verification step passed only --check-format --verbose, so every checked .po was also compiled over that one path, leaving the workspace with a stray messages.mo built from whichever locale happened to be checked last.

Harmless in CI, where the workspace is thrown away and the release zip takes its .mo files from l10n/ -- but the same line exists in the local update_translations.sh, where it overwrites the tracked messages.mo in the repo root on every run and shows up as unexplained churn.

Send the check's output to /dev/null. The compile on the next line already writes the real .mo, and -o does not weaken the check: msgfmt still exits non-zero on a malformed catalogue.