### PR TITLE
Fix redirect target caching: record later hops, drop a target that fails

### DIFF
--- a/zlibrary/api.lua
+++ b/zlibrary/api.lua
@@ -107,6 +107,9 @@ local function _checkAndHandleRedirect(skip_check, status_code, current_url)
         headers = { ["User-Agent"] = Config.USER_AGENT },
         timeout = {5, 10},
         redirect = true,
+        -- This probe only reads the redirect target; it must not disturb the cached one,
+        -- which the onRedirect callback below is about to read to rebuild the retry URL.
+        skipRedirectCache = true,
     })
     
     result.has_redirect = true
@@ -224,6 +227,19 @@ function Api.makeHttpRequest(options)
 
     if not options.sink then
         result.body = table.concat(response_body_table)
+    end
+
+    -- A pinned redirect target that fails at the transport layer, or answers 5xx, is not usable.
+    -- Drop it now instead of keeping every request on it until the TTL lapses. 4xx must not clear
+    -- the pin: a 401 or a download limit is a healthy host answering, not a broken one. 3xx must
+    -- not either, since the redirect handling below still needs the pin to rebuild the retry URL.
+    if not options.skipRedirectCache and
+       (type(result.status_code) ~= "number" or result.status_code >= 500) then
+        if Config.clearCacheRealUrlIfPinned(options.url) then
+            logger.info(string.format(
+                "Zlibrary:Api.makeHttpRequest - Dropped cached redirect target; it failed: %s (status: %s)",
+                tostring(options.url), tostring(result.status_code)))
+        end
     end
 
     if type(result.status_code) ~= "number" then

--- a/zlibrary/config.lua
+++ b/zlibrary/config.lua
@@ -2,6 +2,7 @@ local util = require("util")
 local logger = require("logger")
 local DataStorage = require("datastorage")
 local LuaSettings = require("luasettings")
+local socket_url = require("socket.url")
 local T = require("zlibrary.gettext")
 local Cache = require("zlibrary.cache")
 
@@ -187,13 +188,36 @@ function Config.clearCacheRealUrl()
     return Config.getConfigRuntimeCache():remove("api_real_url")
 end
 
+-- scheme://host[:port] of a url, or nil when it has no parsable origin.
+local function _getUrlOrigin(url)
+    if type(url) ~= "string" or url == "" then
+        return nil
+    end
+    local parsed = socket_url.parse(url)
+    if not (parsed and parsed.scheme and parsed.host) then
+        return nil
+    end
+    return socket_url.build({
+        scheme = parsed.scheme,
+        host = parsed.host,
+        port = parsed.port,
+    })
+end
+
 function Config.setCacheRealUrl(original_url, real_url)
     if not (original_url and real_url) then
         return
     end
-    
-    local base_url = Config.getBaseUrl(true)
-    if not (base_url and string.find(original_url, base_url, 1, true)) then
+
+    -- The redirected request was built by Config.getBaseUrl(), which prefers the cached real url
+    -- over the configured one, so accept either origin. Matching only the configured one would
+    -- reject every hop after the first (A -> B -> C never records C) and leave onRedirect
+    -- retrying the stale host.
+    local origin = _getUrlOrigin(original_url)
+    if not origin then
+        return
+    end
+    if origin ~= _getUrlOrigin(Config.getBaseUrl(true)) and origin ~= _getUrlOrigin(Config.getCacheRealUrl()) then
         return
     end
 
@@ -202,6 +226,26 @@ function Config.setCacheRealUrl(original_url, real_url)
     end
 
     return Config.getConfigRuntimeCache():insert("api_real_url", real_url)
+end
+
+-- Drop the cached redirect target when that very host is the one that just failed.
+-- The cache is otherwise write-once and expire-only, so a target that goes bad keeps every
+-- request pointed at it for the rest of its TTL. Only a failure from the pinned host itself
+-- clears it: a failure from any other host says nothing about whether the pin is still good.
+-- Returns true when a pin was dropped.
+function Config.clearCacheRealUrlIfPinned(url)
+    local cached_url = Config.getCacheRealUrl()
+    if not cached_url then
+        return false
+    end
+
+    local origin = _getUrlOrigin(url)
+    if not origin or origin ~= _getUrlOrigin(cached_url) then
+        return false
+    end
+
+    Config.clearCacheRealUrl()
+    return true
 end
 
 function Config.getBaseUrl(is_original)


### PR DESCRIPTION
Two defects in the api_real_url cache, fixed together because the first one was masking the second.

setCacheRealUrl guarded on Config.getBaseUrl(true), which short-circuits the cache and returns the configured host. Every request URL is built by Config.getBaseUrl() with no argument, which prefers the cached target. So once a target was cached, no request URL contained the configured host any more, the guard rejected the write, and a second hop was never recorded.

That is worse than a missed memo. The write is what makes the follow work: makeHttpRequest caches the target and then calls onRedirect, whose callbacks rebuild the retry URL through Config.getBaseUrl() and read that very write back. With the write skipped, the retry rebuilt the same URL, re-fetched the same redirect and failed. A -> B worked; B -> C could not be followed at all, which is not what the dynamic-URL support intended.

Accept the write when the request came from either the configured or the cached origin, and compare parsed scheme+host+port instead of a plain substring, which matched any host sharing a prefix ("https://z-lib.g" matched "https://z-lib.gd").

Fixing that lets the cache follow longer chains, which widens the second defect, so both land together: the cache was write-once and expire-only. Nothing dropped a target that stopped working -- clearCacheRealUrl's only caller is the user re-saving their base URL -- so a target that went bad took every request down with it for the full 600s TTL. Drop the target when that same host fails at the transport layer or answers 5xx.

Deliberately not cleared on 4xx: a 401 or a download limit is a healthy host answering. Nor on 3xx, where the follow still needs the target to rebuild the retry URL. The redirect probe now passes skipRedirectCache for the same reason: it reads the target, it must not disturb it.

Resolution semantics are untouched. Making callers pass skipRedirectCache, or making getBaseUrl treat the cache as a fallback, would both break redirect following outright, since the cache is the mechanism rather than an optimisation.