### PR TITLE
Download to a temp file so a failure cannot destroy the user's book

### DIFF
--- a/l10n/ar/koreader.po
+++ b/l10n/ar/koreader.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: v1.0.15\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-16 20:19+0200\n"
+"POT-Creation-Date: 2026-07-16 21:26+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -378,6 +378,9 @@ msgid "Failed to open target file"
 msgstr ""
 
 msgid "Download limit reached or file is an HTML page"
+msgstr ""
+
+msgid "Failed to save downloaded file"
 msgstr ""
 
 msgid "Download HTTP Error"

--- a/l10n/bg_BG/koreader.po
+++ b/l10n/bg_BG/koreader.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: zlibrary.koplugin\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-16 20:19+0200\n"
+"POT-Creation-Date: 2026-07-16 21:26+0200\n"
 "PO-Revision-Date: 2026-05-15 21:20+0300\n"
 "Last-Translator: d0nizam\n"
 "Language-Team: Bulgarian\n"
@@ -385,6 +385,9 @@ msgstr "Неуспешно отваряне на целевия файл"
 
 msgid "Download limit reached or file is an HTML page"
 msgstr "Достигнат лимит за изтегляне или файлът е HTML страница"
+
+msgid "Failed to save downloaded file"
+msgstr ""
 
 msgid "Download HTTP Error"
 msgstr "HTTP грешка при изтегляне"

--- a/l10n/de/koreader.po
+++ b/l10n/de/koreader.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: v1.0.15\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-16 20:19+0200\n"
+"POT-Creation-Date: 2026-07-16 21:26+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -378,6 +378,9 @@ msgid "Failed to open target file"
 msgstr ""
 
 msgid "Download limit reached or file is an HTML page"
+msgstr ""
+
+msgid "Failed to save downloaded file"
 msgstr ""
 
 msgid "Download HTTP Error"

--- a/l10n/es/koreader.po
+++ b/l10n/es/koreader.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: v1.0.15\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-16 20:19+0200\n"
+"POT-Creation-Date: 2026-07-16 21:26+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -378,6 +378,9 @@ msgid "Failed to open target file"
 msgstr ""
 
 msgid "Download limit reached or file is an HTML page"
+msgstr ""
+
+msgid "Failed to save downloaded file"
 msgstr ""
 
 msgid "Download HTTP Error"

--- a/l10n/fr/koreader.po
+++ b/l10n/fr/koreader.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: v1.0.15\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-16 20:19+0200\n"
+"POT-Creation-Date: 2026-07-16 21:26+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -378,6 +378,9 @@ msgid "Failed to open target file"
 msgstr ""
 
 msgid "Download limit reached or file is an HTML page"
+msgstr ""
+
+msgid "Failed to save downloaded file"
 msgstr ""
 
 msgid "Download HTTP Error"

--- a/l10n/it_IT/koreader.po
+++ b/l10n/it_IT/koreader.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: v1.0.15\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-16 20:19+0200\n"
+"POT-Creation-Date: 2026-07-16 21:26+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -378,6 +378,9 @@ msgid "Failed to open target file"
 msgstr ""
 
 msgid "Download limit reached or file is an HTML page"
+msgstr ""
+
+msgid "Failed to save downloaded file"
 msgstr ""
 
 msgid "Download HTTP Error"

--- a/l10n/ja/koreader.po
+++ b/l10n/ja/koreader.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: v1.0.15\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-16 20:19+0200\n"
+"POT-Creation-Date: 2026-07-16 21:26+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -378,6 +378,9 @@ msgid "Failed to open target file"
 msgstr ""
 
 msgid "Download limit reached or file is an HTML page"
+msgstr ""
+
+msgid "Failed to save downloaded file"
 msgstr ""
 
 msgid "Download HTTP Error"

--- a/l10n/ko_KR/koreader.po
+++ b/l10n/ko_KR/koreader.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: v1.0.15\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-16 20:19+0200\n"
+"POT-Creation-Date: 2026-07-16 21:26+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -378,6 +378,9 @@ msgid "Failed to open target file"
 msgstr ""
 
 msgid "Download limit reached or file is an HTML page"
+msgstr ""
+
+msgid "Failed to save downloaded file"
 msgstr ""
 
 msgid "Download HTTP Error"

--- a/l10n/koreader.pot
+++ b/l10n/koreader.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-16 20:19+0200\n"
+"POT-Creation-Date: 2026-07-16 21:26+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -73,7 +73,8 @@ msgstr ""
 msgid "Failed"
 msgstr ""
 
-#: main.lua:238 main.lua:371 zlibrary/api.lua:510 zlibrary/api.lua:569
+#: main.lua:238 main.lua:371 zlibrary/api.lua:532 zlibrary/api.lua:592
+#: zlibrary/api.lua:608
 msgid "Unknown error"
 msgstr ""
 
@@ -219,7 +220,7 @@ msgstr ""
 msgid "Recommended"
 msgstr ""
 
-#: main.lua:584 main.lua:726 zlibrary/config.lua:128
+#: main.lua:584 main.lua:726 zlibrary/config.lua:129
 msgid "Most popular"
 msgstr ""
 
@@ -405,37 +406,37 @@ msgstr ""
 msgid "Download failed: Unknown error"
 msgstr ""
 
-#: main.lua:1444 main.lua:1467
+#: main.lua:1444 main.lua:1466
 msgid "Download limit reached. Please try again later or check your account."
 msgstr ""
 
-#: main.lua:1473 zlibrary/bookdetails_dialog.lua:415 zlibrary/ui.lua:504
+#: main.lua:1471 zlibrary/bookdetails_dialog.lua:415 zlibrary/ui.lua:504
 #: zlibrary/ui.lua:511 zlibrary/ui.lua:910
 msgid "Download"
 msgstr ""
 
-#: main.lua:1475
+#: main.lua:1473
 msgid "Retrying download..."
 msgstr ""
 
-#: main.lua:1510 zlibrary/api.lua:1239
+#: main.lua:1509 zlibrary/api.lua:1278
 msgid "Book ID is required."
 msgstr ""
 
-#: main.lua:1535
+#: main.lua:1534
 msgid "Loading comments..."
 msgstr ""
 
-#: main.lua:1536
+#: main.lua:1535
 msgid "Failed to load comments"
 msgstr ""
 
-#: main.lua:1537 zlibrary/bookdetails_dialog.lua:243
+#: main.lua:1536 zlibrary/bookdetails_dialog.lua:243
 #: zlibrary/bookdetails_dialog.lua:437 zlibrary/ui.lua:925 zlibrary/ui.lua:930
 msgid "Comments"
 msgstr ""
 
-#: main.lua:1543
+#: main.lua:1542
 msgid "No comments to display"
 msgstr ""
 
@@ -443,241 +444,245 @@ msgstr ""
 msgid "Could not find the server address"
 msgstr ""
 
-#: zlibrary/api.lua:216 zlibrary/api.lua:243
+#: zlibrary/api.lua:219 zlibrary/api.lua:259
 msgid "Request timed out - please check your connection and try again"
 msgstr ""
 
-#: zlibrary/api.lua:218 zlibrary/ui.lua:640
+#: zlibrary/api.lua:221 zlibrary/ui.lua:640
 msgid "Network request failed"
 msgstr ""
 
-#: zlibrary/api.lua:254
+#: zlibrary/api.lua:270
 msgid "The Z-library address may be wrong or no longer exist."
 msgstr ""
 
-#: zlibrary/api.lua:256
+#: zlibrary/api.lua:272
 msgid ""
 "Network connection error - please check your internet connection and try "
 "again"
 msgstr ""
 
-#: zlibrary/api.lua:291 zlibrary/api.lua:553
+#: zlibrary/api.lua:307 zlibrary/api.lua:582
 msgid "HTTP Error"
 msgstr ""
 
-#: zlibrary/api.lua:291
+#: zlibrary/api.lua:307
 msgid "Unknown Status"
 msgstr ""
 
-#: zlibrary/api.lua:307 zlibrary/api.lua:396
+#: zlibrary/api.lua:323 zlibrary/api.lua:412
 msgid ""
 "The Z-library server address (URL) is not set. Please configure it in the Z-"
 "library plugin settings."
 msgstr ""
 
-#: zlibrary/api.lua:344
+#: zlibrary/api.lua:360
 msgid "Login failed: Empty response from server"
 msgstr ""
 
-#: zlibrary/api.lua:352
+#: zlibrary/api.lua:368
 msgid "Login failed: Invalid response format"
 msgstr ""
 
-#: zlibrary/api.lua:364 zlibrary/api.lua:379
+#: zlibrary/api.lua:380 zlibrary/api.lua:395
 msgid "Login failed"
 msgstr ""
 
-#: zlibrary/api.lua:370
+#: zlibrary/api.lua:386
 msgid "Login failed: Invalid session data"
 msgstr ""
 
-#: zlibrary/api.lua:379
+#: zlibrary/api.lua:395
 msgid "Credentials rejected or invalid response"
 msgstr ""
 
-#: zlibrary/api.lua:457
+#: zlibrary/api.lua:473
 msgid "No response received from server - please try again"
 msgstr ""
 
-#: zlibrary/api.lua:465
+#: zlibrary/api.lua:481
 msgid "Invalid response format from server"
 msgstr ""
 
-#: zlibrary/api.lua:471
+#: zlibrary/api.lua:487
 msgid "Search API error"
 msgstr ""
 
-#: zlibrary/api.lua:510 zlibrary/api.lua:569
+#: zlibrary/api.lua:532 zlibrary/api.lua:608
 msgid "Failed to open target file"
 msgstr ""
 
-#: zlibrary/api.lua:546
+#: zlibrary/api.lua:575
 msgid "Download limit reached or file is an HTML page"
 msgstr ""
 
-#: zlibrary/api.lua:600
+#: zlibrary/api.lua:592
+msgid "Failed to save downloaded file"
+msgstr ""
+
+#: zlibrary/api.lua:639
 msgid "Download HTTP Error"
 msgstr ""
 
-#: zlibrary/api.lua:615 zlibrary/api.lua:663 zlibrary/api.lua:829
-#: zlibrary/api.lua:882 zlibrary/api.lua:941 zlibrary/api.lua:996
-#: zlibrary/api.lua:1045 zlibrary/api.lua:1092 zlibrary/api.lua:1139
+#: zlibrary/api.lua:654 zlibrary/api.lua:702 zlibrary/api.lua:868
+#: zlibrary/api.lua:921 zlibrary/api.lua:980 zlibrary/api.lua:1035
+#: zlibrary/api.lua:1084 zlibrary/api.lua:1131 zlibrary/api.lua:1178
 msgid "Z-library server URL not configured."
 msgstr ""
 
-#: zlibrary/api.lua:641
+#: zlibrary/api.lua:680
 msgid "Failed to fetch recommended books (no response body)."
 msgstr ""
 
-#: zlibrary/api.lua:647
+#: zlibrary/api.lua:686
 msgid "Failed to parse recommended books response."
 msgstr ""
 
-#: zlibrary/api.lua:652
+#: zlibrary/api.lua:691
 msgid "API returned an error for recommended books."
 msgstr ""
 
-#: zlibrary/api.lua:689
+#: zlibrary/api.lua:728
 msgid "Failed to fetch most popular books (no response body)."
 msgstr ""
 
-#: zlibrary/api.lua:695
+#: zlibrary/api.lua:734
 msgid "Failed to parse most popular books response."
 msgstr ""
 
-#: zlibrary/api.lua:700
+#: zlibrary/api.lua:739
 msgid "API returned an error for most popular books."
 msgstr ""
 
-#: zlibrary/api.lua:711 zlibrary/api.lua:766 zlibrary/api.lua:1247
+#: zlibrary/api.lua:750 zlibrary/api.lua:805 zlibrary/api.lua:1286
 msgid "Z-library server URL not configured or book identifiers missing."
 msgstr ""
 
-#: zlibrary/api.lua:739
+#: zlibrary/api.lua:778
 msgid "Failed to fetch book details (no response body)."
 msgstr ""
 
-#: zlibrary/api.lua:745
+#: zlibrary/api.lua:784
 msgid "Failed to parse book details response."
 msgstr ""
 
-#: zlibrary/api.lua:750
+#: zlibrary/api.lua:789
 msgid "API returned an error for book details."
 msgstr ""
 
-#: zlibrary/api.lua:756
+#: zlibrary/api.lua:795
 msgid "Failed to process book details."
 msgstr ""
 
-#: zlibrary/api.lua:794
+#: zlibrary/api.lua:833
 msgid "Failed to fetch download link (no response body)."
 msgstr ""
 
-#: zlibrary/api.lua:800
+#: zlibrary/api.lua:839
 msgid "Failed to parse download link response."
 msgstr ""
 
-#: zlibrary/api.lua:805
+#: zlibrary/api.lua:844
 msgid "API returned an error for download link."
 msgstr ""
 
-#: zlibrary/api.lua:813
+#: zlibrary/api.lua:852
 msgid "No download link provided in API response."
 msgstr ""
 
-#: zlibrary/api.lua:857
+#: zlibrary/api.lua:896
 msgid "Failed to fetch similar books (no response body)."
 msgstr ""
 
-#: zlibrary/api.lua:863
+#: zlibrary/api.lua:902
 msgid "Failed to parse similar books response."
 msgstr ""
 
-#: zlibrary/api.lua:868
+#: zlibrary/api.lua:907
 msgid "API returned an error for similar books."
 msgstr ""
 
-#: zlibrary/api.lua:910
+#: zlibrary/api.lua:949
 msgid "Failed to fetch downloaded books (no response body)."
 msgstr ""
 
-#: zlibrary/api.lua:917
+#: zlibrary/api.lua:956
 msgid "Failed to parse downloaded books response."
 msgstr ""
 
-#: zlibrary/api.lua:922
+#: zlibrary/api.lua:961
 msgid "API returned an error for downloaded books."
 msgstr ""
 
-#: zlibrary/api.lua:969
+#: zlibrary/api.lua:1008
 msgid "Failed to fetch favorite books (no response body)."
 msgstr ""
 
-#: zlibrary/api.lua:975
+#: zlibrary/api.lua:1014
 msgid "Failed to parse favorite books response."
 msgstr ""
 
-#: zlibrary/api.lua:980
+#: zlibrary/api.lua:1019
 msgid "API returned an error for favorite books."
 msgstr ""
 
-#: zlibrary/api.lua:1024
+#: zlibrary/api.lua:1063
 msgid "Failed to fetch unfavorite book (no response body)."
 msgstr ""
 
-#: zlibrary/api.lua:1030
+#: zlibrary/api.lua:1069
 msgid "Failed to parse unfavorite book response."
 msgstr ""
 
-#: zlibrary/api.lua:1035
+#: zlibrary/api.lua:1074
 msgid "API returned an error for unfavorite book."
 msgstr ""
 
-#: zlibrary/api.lua:1071
+#: zlibrary/api.lua:1110
 msgid "Failed to fetch download quota status (no response body)."
 msgstr ""
 
-#: zlibrary/api.lua:1077
+#: zlibrary/api.lua:1116
 msgid "Failed to parse download quota status response."
 msgstr ""
 
-#: zlibrary/api.lua:1082
+#: zlibrary/api.lua:1121
 msgid "API returned an error for download quota status."
 msgstr ""
 
-#: zlibrary/api.lua:1118
+#: zlibrary/api.lua:1157
 msgid "Failed to fetch favorite-book IDs (no response body)."
 msgstr ""
 
-#: zlibrary/api.lua:1124
+#: zlibrary/api.lua:1163
 msgid "Failed to parse favorite-book IDs."
 msgstr ""
 
-#: zlibrary/api.lua:1129
+#: zlibrary/api.lua:1168
 msgid "API returned an error for favorite-book IDs."
 msgstr ""
 
-#: zlibrary/api.lua:1167
+#: zlibrary/api.lua:1206
 msgid "Failed to fetch favorite book (no response body)."
 msgstr ""
 
-#: zlibrary/api.lua:1173
+#: zlibrary/api.lua:1212
 msgid "Failed to parse favorite book response."
 msgstr ""
 
-#: zlibrary/api.lua:1178
+#: zlibrary/api.lua:1217
 msgid "API returned an error for favorite book."
 msgstr ""
 
-#: zlibrary/api.lua:1275
+#: zlibrary/api.lua:1314
 msgid "Failed to fetch book comments (no response body)."
 msgstr ""
 
-#: zlibrary/api.lua:1283
+#: zlibrary/api.lua:1322
 msgid "Failed to parse book comments response."
 msgstr ""
 
-#: zlibrary/api.lua:1290
+#: zlibrary/api.lua:1329
 msgid "API returned an error for book comments."
 msgstr ""
 
@@ -725,36 +730,36 @@ msgstr ""
 msgid "No Description"
 msgstr ""
 
-#: zlibrary/config.lua:129
+#: zlibrary/config.lua:130
 msgid "Best match"
 msgstr ""
 
-#: zlibrary/config.lua:130
+#: zlibrary/config.lua:131
 msgid "Recently added"
 msgstr ""
 
-#: zlibrary/config.lua:131 zlibrary/config.lua:132
+#: zlibrary/config.lua:132 zlibrary/config.lua:133
 #: zlibrary/multisearch_dialog.lua:369
 msgid "Title"
 msgstr ""
 
-#: zlibrary/config.lua:133
+#: zlibrary/config.lua:134
 msgid "Year"
 msgstr ""
 
-#: zlibrary/config.lua:134 zlibrary/config.lua:135
+#: zlibrary/config.lua:135 zlibrary/config.lua:136
 msgid "File size"
 msgstr ""
 
-#: zlibrary/config.lua:462
+#: zlibrary/config.lua:506
 msgid "Default"
 msgstr ""
 
-#: zlibrary/config.lua:542 zlibrary/ui.lua:741 zlibrary/ui.lua:774
+#: zlibrary/config.lua:586 zlibrary/ui.lua:741 zlibrary/ui.lua:774
 msgid "infinite"
 msgstr ""
 
-#: zlibrary/config.lua:543
+#: zlibrary/config.lua:587
 #, lua-format
 msgid "Block: %ds, Total: %s"
 msgstr ""

--- a/l10n/nl_NL/koreader.po
+++ b/l10n/nl_NL/koreader.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: v1.0.15\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-16 20:19+0200\n"
+"POT-Creation-Date: 2026-07-16 21:26+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -378,6 +378,9 @@ msgid "Failed to open target file"
 msgstr ""
 
 msgid "Download limit reached or file is an HTML page"
+msgstr ""
+
+msgid "Failed to save downloaded file"
 msgstr ""
 
 msgid "Download HTTP Error"

--- a/l10n/pl/koreader.po
+++ b/l10n/pl/koreader.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: v1.0.15\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-16 20:19+0200\n"
+"POT-Creation-Date: 2026-07-16 21:26+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -378,6 +378,9 @@ msgid "Failed to open target file"
 msgstr ""
 
 msgid "Download limit reached or file is an HTML page"
+msgstr ""
+
+msgid "Failed to save downloaded file"
 msgstr ""
 
 msgid "Download HTTP Error"

--- a/l10n/pt_BR/koreader.po
+++ b/l10n/pt_BR/koreader.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: v1.0.15\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-16 20:19+0200\n"
+"POT-Creation-Date: 2026-07-16 21:26+0200\n"
 "PO-Revision-Date: 2025-05-28 15:14-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -379,6 +379,9 @@ msgid "Failed to open target file"
 msgstr ""
 
 msgid "Download limit reached or file is an HTML page"
+msgstr ""
+
+msgid "Failed to save downloaded file"
 msgstr ""
 
 msgid "Download HTTP Error"

--- a/l10n/ru/koreader.po
+++ b/l10n/ru/koreader.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: v1.0.15\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-16 20:19+0200\n"
+"POT-Creation-Date: 2026-07-16 21:26+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Russian <ru@li.org>\n"
@@ -378,6 +378,9 @@ msgid "Failed to open target file"
 msgstr ""
 
 msgid "Download limit reached or file is an HTML page"
+msgstr ""
+
+msgid "Failed to save downloaded file"
 msgstr ""
 
 msgid "Download HTTP Error"

--- a/l10n/zh_CN/koreader.po
+++ b/l10n/zh_CN/koreader.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: v1.0.15\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-16 20:19+0200\n"
+"POT-Creation-Date: 2026-07-16 21:26+0200\n"
 "PO-Revision-Date: 2026-04-03 00:00+0800\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: zh <zh@li.org>\n"
@@ -379,6 +379,9 @@ msgstr "无法打开目标文件"
 
 msgid "Download limit reached or file is an HTML page"
 msgstr "已达下载限制或文件为HTML页面"
+
+msgid "Failed to save downloaded file"
+msgstr ""
 
 msgid "Download HTTP Error"
 msgstr "下载 HTTP 错误"

--- a/l10n/zh_TW/koreader.po
+++ b/l10n/zh_TW/koreader.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: v1.0.15\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-16 20:19+0200\n"
+"POT-Creation-Date: 2026-07-16 21:26+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Chinese <zh@li.org>\n"
@@ -378,6 +378,9 @@ msgid "Failed to open target file"
 msgstr ""
 
 msgid "Download limit reached or file is an HTML page"
+msgstr ""
+
+msgid "Failed to save downloaded file"
 msgstr ""
 
 msgid "Download HTTP Error"

--- a/main.lua
+++ b/main.lua
@@ -1446,7 +1446,6 @@ function Zlibrary:downloadBook(book)
                     fail_msg = api_result.error
                 end
                 Ui.showErrorMessage(fail_msg)
-                pcall(os.remove, target_filepath)
             end
         end
 
@@ -1465,7 +1464,6 @@ function Zlibrary:downloadBook(book)
             if string.find(error_string, "Download limit reached or file is an HTML page", 1, true) then
                 Ui.closeMessage(loading_msg)
                 Ui.showErrorMessage(T("Download limit reached. Please try again later or check your account."))
-                pcall(os.remove, target_filepath)
                 return
             end
             
@@ -1475,8 +1473,9 @@ function Zlibrary:downloadBook(book)
                 loading_msg, progress_callback = Ui.showBookDownloadProgress(book, T("Retrying download..."))
                 AsyncHelper.run(task_download, on_success_download, on_error_download, loading_msg)
             end, function(final_err_msg)
-                -- Cancel callback - user already knows about the error
-                pcall(os.remove, target_filepath)
+                -- Cancel callback - user already knows about the error. Nothing to clean up:
+                -- Api.downloadBook discards its own temp file, and this path is also reached when
+                -- Api.getDownloadLink failed and no file was ever created.
             end, loading_msg)
         end
 

--- a/zlibrary/api.lua
+++ b/zlibrary/api.lua
@@ -521,11 +521,24 @@ function Api.downloadBook(download_url, target_filepath, user_id, user_key, refe
     end
 
     local result = { success = false, error = nil }
-    local file, err_open = io.open(target_filepath, "wb")
+
+    -- Download into a sibling temp file and rename onto target_filepath only once the whole body has
+    -- arrived. Opening target_filepath directly would truncate an existing book before the first byte
+    -- is fetched, and every failure below would then delete it -- so a quota-blocked re-download of a
+    -- book the user already owns would destroy their copy. CoverCache does the same thing for covers.
+    local temp_filepath = target_filepath .. ".downloading"
+    local file, err_open = io.open(temp_filepath, "wb")
     if not file then
         result.error = T("Failed to open target file") .. ": " .. (err_open or T("Unknown error"))
         logger.err(string.format("Zlibrary:Api.downloadBook - END (File open error) - Error: %s", result.error))
         return result
+    end
+
+    -- The sink closes the handle at end of stream, but not when the request fails before it is ever
+    -- called, so close defensively; a double close is harmless here.
+    local function discardTempFile()
+        pcall(function() file:close() end)
+        pcall(os.remove, temp_filepath)
     end
 
     local headers = { ["User-Agent"] = Config.USER_AGENT }
@@ -552,7 +565,7 @@ function Api.downloadBook(download_url, target_filepath, user_id, user_key, refe
 
     if http_result.error and not (http_result.status_code and http_result.headers) then
         result.error = http_result.error
-        pcall(os.remove, target_filepath)
+        discardTempFile()
         logger.err(string.format("Zlibrary:Api.downloadBook - END (Request error) - Error: %s", result.error))
         return result
     end
@@ -560,17 +573,27 @@ function Api.downloadBook(download_url, target_filepath, user_id, user_key, refe
     local content_type = http_result.headers and http_result.headers["content-type"]
     if content_type and string.find(string.lower(content_type), "text/html") then
         result.error = T("Download limit reached or file is an HTML page")
-        pcall(os.remove, target_filepath)
+        discardTempFile()
         logger.warn(string.format("Zlibrary:Api.downloadBook - END (HTML content detected) - URL: %s, Status: %s, Content-Type: %s", download_url, tostring(http_result.status_code), content_type))
         return result
     end
 
     if http_result.error or (http_result.status_code and http_result.status_code ~= 200) then
         result.error = http_result.error or string.format("%s: %s", T("HTTP Error"), http_result.status_code)
-        pcall(os.remove, target_filepath)
+        discardTempFile()
         logger.err(string.format("Zlibrary:Api.downloadBook - END (Download error) - Error: %s, Status: %s", result.error, tostring(http_result.status_code)))
         return result
     else
+        pcall(function() file:close() end)
+        -- Same directory, so this is an atomic replace; the user's copy is only ever replaced by a
+        -- complete download.
+        local renamed, err_rename = os.rename(temp_filepath, target_filepath)
+        if not renamed then
+            result.error = T("Failed to save downloaded file") .. ": " .. tostring(err_rename or T("Unknown error"))
+            discardTempFile()
+            logger.err(string.format("Zlibrary:Api.downloadBook - END (Rename error) - Error: %s", result.error))
+            return result
+        end
         result.success = true
         logger.info(string.format("Zlibrary:Api.downloadBook - END (Success) - Target: %s", target_filepath))
         return result


### PR DESCRIPTION
Api.downloadBook opened target_filepath with "wb" before fetching a single byte, truncating whatever was already there, and then removed that same path on every failure. target_filepath is the real library path and the filename is deterministic, so re-downloading a book you already own and hitting any error deleted your readable copy.

The quota case makes this routine rather than exotic: tap Download on a book you own, hit the daily limit, and the server answers 200 with an HTML limit page. downloadBook removes the file and reports "Download limit reached" -- the book is gone. A mid-stream drop, a 5xx, or pressing Cancel on the retry dialog did the same.

Download into "<target>.downloading" and os.rename onto target_filepath only after the whole body has arrived. Same directory, so the rename is an atomic replace and the existing file is only ever swapped for a complete download. This is what CoverCache already does for covers, via getTempPath.

downloadBook now owns the temp file end to end, so the three os.remove calls in main.lua are gone rather than repointed. One of them was the sharpest edge: the retry dialog's cancel callback is also reached when Api.getDownloadLink fails, before downloadBook is ever entered, so it deleted a book no download had opened or created.

Also close the file handle explicitly before discarding the temp. The sink closes it at end of stream, but not when the request fails before the sink is ever called -- a DNS failure being the obvious case.

Api.downloadBookCover is untouched: its only caller already hands it a CoverCache temp path, so its removes were always hitting the temp.

Verified with a harness driving each failure mode against a real file on disk: before, the quota page / transport failure / mid-stream drop / 500 each left the target deleted; after, the file survives all four and a successful download still replaces it.