### PR TITLE
Fix crash when a selection dialog is closed with nothing selected

### DIFF
--- a/zlibrary/ui.lua
+++ b/zlibrary/ui.lua
@@ -245,15 +245,21 @@ local function _showMultiSelectionDialog(parent_ui, title, setting_key, options_
                     return #new_selected_values
                 else
                     Config.deleteSetting(setting_key)
+                    -- Return the count rather than falling off the end: selecting nothing is a
+                    -- normal outcome, and the callers below need a number.
+                    return 0
                 end
             end)
 
             UIManager:close(selection_menu)
             if ok then
+                local selected_count = err or 0
                 if type(ok_callback) == "function" then
-                    ok_callback(err)
+                    ok_callback(selected_count)
+                elseif selected_count > 0 then
+                    Ui.showInfoMessage(string.format(T("%d items selected for %s."), selected_count, title))
                 else
-                    Ui.showInfoMessage(string.format(T("%d items selected for %s."), err, title))
+                    Ui.showInfoMessage(string.format(T("Filter cleared for %s."), title))
                 end
             else
                 logger.err("Zlibrary:Ui._editConfigOptionsDialog - Error during onClose for %s: %s", title, tostring(err))


### PR DESCRIPTION
_showMultiSelectionDialog's onClose returns the selection count from its pcall'd closure, but only on the branch where something was selected. The empty branch called Config.deleteSetting and fell off the end, so the pcall yielded ok=true with a nil second value -- and the display path then ran string.format("%d items selected for %s.", nil, title) outside the pcall, raising "bad argument #2 to 'format' (number expected, got nil)" out of a UIManager event handler.

Both callers that omit ok_callback reach that line: Select search languages and Select search formats. Their settings default to empty, so on a fresh install merely opening either one and pressing Back crashes, without the user selecting anything. Deselecting everything to clear a filter -- the documented way to do it -- crashes too.

Return 0 explicitly from the empty branch, and report a cleared filter rather than "0 items selected for X", using the message id that path already uses. ok_callback consumers now always receive a number.