### PR TITLE
Detect a failed unzip when installing an update

### DIFF
--- a/zlibrary/ota.lua
+++ b/zlibrary/ota.lua
@@ -190,15 +190,13 @@ function Ota.installUpdate(zip_filepath, plugin_base_path)
     local unzip_command = string.format("unzip -o '%s' -d '%s' -x '%s'", zip_filepath, target_unzip_dir, excluded_file_path_in_zip)
     logger.info("Zlibrary:Ota.installUpdate - Executing: " .. unzip_command)
 
-    local ok, err_code, err_msg_os = os.execute(unzip_command)
+    -- LuaJIT keeps Lua 5.1's os.execute: it returns the raw system() status as a single number and
+    -- nothing else, so the extra return values were always nil and, worse, 0 is truthy in Lua --
+    -- `if not ok` could never fire. Compare against 0, as KOReader does at every other call site.
+    local exec_status = os.execute(unzip_command)
 
-    if not ok then
-        local error_detail = "Unknown error"
-        if type(err_code) == "number" then
-            error_detail = "Exit code: " .. err_code
-        elseif type(err_msg_os) == "string" then
-            error_detail = err_msg_os
-        end
+    if exec_status ~= 0 then
+        local error_detail = "unzip status: " .. tostring(exec_status)
         logger.err("Zlibrary:Ota.installUpdate - Failed to extract ZIP: " .. error_detail .. " Command: " .. unzip_command)
         _show_ota_final_message(T("Update installation failed."), true)
         return { error = "Failed to extract update package: " .. error_detail }


### PR DESCRIPTION
installUpdate tested `local ok, err_code, err_msg_os = os.execute(cmd)` followed by `if not ok then`, which is Lua 5.4's contract. KOReader runs LuaJIT, which keeps Lua 5.1's: os.execute returns the raw system() status as a single number and nothing else. So err_code and err_msg_os were always nil, and -- because 0 is truthy in Lua -- `not ok` was false whatever happened. The entire error branch was unreachable.

A failed extraction therefore fell straight through to "ZIP extracted successfully", deleted the downloaded zip, and told the user the update had installed. A corrupt download, a full disk, or unzip simply not being present all produced a confident success message and no update, with the zip that might have been retried already removed.

Compare the status against 0, which is what KOReader does at every one of its own os.execute call sites. Verified on KOReader's own LuaJIT: os.execute("exit 3") returns 768, so `not ok` is false while `~= 0` is true.

Exercised against real unzip invocations: a valid zip still installs; a corrupt zip and a missing unzip binary are both now detected, and the downloaded zip survives for a retry instead of being deleted.