### PR TITLE
Cancel base URL discovery when its menu is closed

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -200,7 +200,10 @@ function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
                 
                 on_start = function(idx, seed)
                     local pos = idx + offset
-                    if is_interactive and connection_menu then
+                    -- Match the on_item_end guard below: clearTasks cannot recall a probe that has
+                    -- already forked, so this can still fire after the menu is gone, and
+                    -- updateItems would repaint through show_parent onto whatever is on screen now.
+                    if is_interactive and connection_menu and UIManager:isWidgetShown(connection_menu) then
                         local item = connection_menu.item_table[pos]
                         if item then
                             item.mandatory = "\u{27F3} " .. T("Checking")
@@ -386,10 +389,13 @@ function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
             if connection_menu and connection_menu.onFirstPage then connection_menu:onFirstPage() end
         end})
 
-        connection_menu = Ui.showUrlCheckProgress(self, menu_items, function() 
-            self.discover_channel:clearTasks()
-            is_discovering = false
+        connection_menu = Ui.showUrlCheckProgress(self, menu_items, function()
+            -- Clear the state BEFORE clearTasks: it runs the session abort hooks synchronously, and
+            -- the batch hook calls on_batch_end -> finishDiscovery, which would otherwise still see
+            -- first_working_url and set the base URL the user just walked away from.
             first_working_url = nil
+            is_discovering = false
+            self.discover_channel:clearTasks()
         end)
     end
 

--- a/zlibrary/ui.lua
+++ b/zlibrary/ui.lua
@@ -990,8 +990,8 @@ function Ui.showUrlCheckProgress(parent_zlibrary, menu_items, close_callback)
         title_bar_fm_style = true,
         single_line = true,
     }
-    function menu:onCloseWidget() 
-        if type(close_callback) == "" then close_callback() end
+    function menu:onCloseWidget()
+        if type(close_callback) == "function" then close_callback() end
         Menu.onCloseWidget(self)
     end
     _showAndTrackDialog(menu)


### PR DESCRIPTION
Ui.showUrlCheckProgress's onCloseWidget tested `type(close_callback) == ""`. type() never returns an empty string, so the branch was unconditionally false and the callback was dead code -- "function" was plainly meant.

The callback that never ran is the discovery teardown. Nothing else cancels it: menu.lua's _clearTasks only touches the cover and preloader channels, not discover_channel. So closing the menu mid-discovery left the queued seed probes forking subprocesses, and when the orphaned batch drained, finishDiscovery still set the base URL and popped "Successfully set base URL to: ..." over whatever the user was reading.

Fixing the guard alone is not enough, and would have swapped a delayed bug for an instant one. Channel:clearTasks runs its session abort hooks synchronously, and executeBatch's hook calls on_batch_end -> finishDiscovery inside that call -- before the next line could clear first_working_url. The base URL would have been overwritten the moment the user closed the menu. Clear the state first, then clear the tasks.

Also guard on_start with UIManager:isWidgetShown, as on_item_end already is. clearTasks cannot recall a probe that has already forked, so on_start can still fire after the menu is gone, and its connection_menu:updateItems call repaints through show_parent -- a live widget -- putting stray updates on the current screen.