### PR TITLE
Validate the server-supplied book hash before using it as a path

### DIFF
--- a/zlibrary/cache.lua
+++ b/zlibrary/cache.lua
@@ -9,6 +9,14 @@ local logger = require("logger")
 local DEF_TTL_CACHE_EXPIRY = 432000 -- 5 days
 local BASE_CACHE_DIR = DataStorage:getDataDir() .. "/cache/zlibrary"
 
+-- book_hash arrives verbatim from the server's JSON and is pasted straight into a filesystem path,
+-- so it has to be treated as untrusted: a hash containing a slash or ".." would steer the cache's
+-- writes, reads and unlinks outside BASE_CACHE_DIR. Real z-library hashes are hex, so accepting only
+-- word characters, underscores and dashes rejects traversal without rejecting anything genuine.
+local function _isValidBookHash(book_hash)
+    return type(book_hash) == "string" and book_hash:match("^[%w_-]+$") ~= nil
+end
+
 local BaseCache = {}
 BaseCache.__index = BaseCache
 
@@ -145,7 +153,7 @@ function BookInfoCache:getPath(book_hash)
 end
 
 function BookInfoCache:insert(book_hash, info_table)
-    if type(book_hash) ~= "string" or type(info_table) ~= "table" then return false end
+    if not _isValidBookHash(book_hash) or type(info_table) ~= "table" then return false end
     self:_ensurePath(self._target_dir)
     local path = self:getPath(book_hash)
     local book_cache = LuaSettings:open(path)
@@ -156,7 +164,7 @@ function BookInfoCache:insert(book_hash, info_table)
 end
 
 function BookInfoCache:get(book_hash, cache_expiry, skip_rm)
-    if type(book_hash) ~= "string" then return nil end
+    if not _isValidBookHash(book_hash) then return nil end
     local path = self:getPath(book_hash)
     if not util.fileExists(path) then return nil end
 
@@ -179,7 +187,7 @@ function BookInfoCache:get(book_hash, cache_expiry, skip_rm)
 end
 
 function BookInfoCache:remove(book_hash)
-    if type(book_hash) ~= "string" then return false end
+    if not _isValidBookHash(book_hash) then return false end
     local path = self:getPath(book_hash)
     if util.fileExists(path) then
         return os.remove(path)
@@ -204,13 +212,13 @@ function CoverCache:getPath(book_hash)
 end
 
 function CoverCache:getTempPath(book_hash)
-    if type(book_hash) ~= "string" or book_hash == "" then return nil end
+    if not _isValidBookHash(book_hash) then return nil end
     self:_ensurePath(self._target_dir)
     return ("%s/%s.jpg.downloading"):format(self._target_dir, book_hash)
 end
 
 function CoverCache:insert(book_hash, source_file_path)
-    if type(book_hash) ~= "string" or type(source_file_path) ~= "string" then return false end
+    if not _isValidBookHash(book_hash) or type(source_file_path) ~= "string" then return false end
     if not util.fileExists(source_file_path) then return false end
     self:_ensurePath(self._target_dir)
     local target_path = self:getPath(book_hash)
@@ -221,7 +229,7 @@ function CoverCache:insert(book_hash, source_file_path)
 end
 
 function CoverCache:get(book_hash, cache_expiry)
-    if type(book_hash) ~= "string" or book_hash == "" then return nil end
+    if not _isValidBookHash(book_hash) then return nil end
     local path = self:getPath(book_hash)
     if util.fileExists(path) then 
         if type(cache_expiry) == "number" then
@@ -240,7 +248,7 @@ function CoverCache:get(book_hash, cache_expiry)
 end
 
 function CoverCache:remove(book_hash)
-    if type(book_hash) ~= "string" or book_hash == "" then return false end
+    if not _isValidBookHash(book_hash) then return false end
     local path = self:getPath(book_hash)
     local temp_path = self:getTempPath(book_hash)
     

--- a/zlibrary/preloader.lua
+++ b/zlibrary/preloader.lua
@@ -26,7 +26,9 @@ function ApiHelper.downloadCover(url, book_hash, skip_conflicts)
     local cache_path = cover_cache:get(book_hash)
     if cache_path then return true end
     local temp_path = cover_cache:getTempPath(book_hash)
-   if util.fileExists(temp_path) and skip_conflicts then return false end
+    -- nil when the server's hash is not usable as a path component; util.fileExists would raise on it
+    if not temp_path then return false end
+    if util.fileExists(temp_path) and skip_conflicts then return false end
     util.removeFile(temp_path)
     local res = Api.downloadBookCover(url, temp_path)
     if not res or res.error or not res.success then


### PR DESCRIPTION
book.hash is copied verbatim out of the server's JSON and pasted straight into three filesystem paths: BookInfoCache:getPath, CoverCache:getPath and CoverCache:getTempPath. None validated it -- getPath did no checking at all, and getTempPath only rejected a non-string or an empty string, which "../.." passes.

The sinks act on whatever path comes back: preloader unlinks the temp path, Api.downloadBookCover opens it "wb" and writes the response to it, and _safeCopy renames it onto getPath's result. So a hostile or hijacked mirror returning hash = "../../../../foo" gets an out-of-directory unlink and write. It needs no user interaction: the cover preloader fires on page turns, so scrolling a results list is enough. Base URLs are auto-discovered from a domain list, and z-library domains do change hands.

Reject any hash that is not word characters, underscores or dashes at every entry point. Real hashes are hex, so nothing genuine is refused. The existing guards were already the right place -- they only checked the type.

preloader now handles a nil temp path. getTempPath could already return nil for an empty hash and preloader passed it straight to util.fileExists, which opens it and would raise; stricter validation makes that reachable.

Bounded rather than critical: the mandatory .jpg / .jpg.downloading / _info.lua suffixes constrain the filename, the rename to .jpg only lands if RenderImage accepts the bytes, and LuaSettings escapes its own output, so the _info.lua write cannot inject Lua. It is still an arbitrary unlink and write outside the cache directory.

Verified against real files: before, cover:remove with a traversing hash deleted a file outside the cache and cover:insert overwrote it with attacker bytes; after, every entry point refuses and the file survives, while hex hashes still cache normally.