### PR TITLE
Report the real reason when the download endpoint withholds a link

### DIFF
--- a/zlibrary/api.lua
+++ b/zlibrary/api.lua
@@ -865,9 +865,21 @@ function Api.getDownloadLink(user_id, user_key, book_id, book_hash)
 
     local file_data = data.file
     local download_link = file_data.downloadLink
-    
+
     if not download_link then
         logger.warn("Api.getDownloadLink - No download link in response: ", http_result.body)
+        -- The endpoint answers 200 with success=1 and the file record, but no link, when the account
+        -- may not download it right now -- an exhausted daily quota being the usual reason. It says
+        -- why in disallowDownloadMessage, which names the limit and how long until it resets, so
+        -- prefer it over a generic string. It arrives as HTML.
+        if file_data.allowDownload == false then
+            local reason = type(file_data.disallowDownloadMessage) == "string"
+                and util.trim(util.htmlToPlainText(file_data.disallowDownloadMessage)) or nil
+            if reason and reason ~= "" then
+                return { error = reason }
+            end
+            return { error = T("Download limit reached. Please try again later or check your account.") }
+        end
         return { error = T("No download link provided in API response.") }
     end
 


### PR DESCRIPTION
Hitting the daily quota showed "No download link provided in API response."

The file endpoint answers 200 with success=1 and the file record, but with no downloadLink, when the account may not download right now. It says why:

  {"success":1,"file":{"allowDownload":false,
   "disallowDownloadMessage":"...your daily limit <span ...>10&nbsp;downloads
   </span> is already reached for today :( You can wait <span ...>41&nbsp;
   minutes</span> for the download counter being reset..."}}

allowDownload was already being parsed and passed through as allow_download, which nothing reads; disallowDownloadMessage was never read at all. So the code fell through to its generic "no link" branch and threw away an explanation that names both the limit and the wait.

Check allowDownload, and show the server's own message: it is more useful than anything we can say, since only it knows the numbers. It arrives as HTML, so run it through util.htmlToPlainText, which the plugin already uses for other server-supplied strings -- that strips the spans and decodes &nbsp;. Fall back to our translated message when the field is missing, and leave the original message in place for a missing link that is NOT a permission problem.

This is a second, earlier quota path than the one already handled: that one fires when the download URL itself returns an HTML limit page, this one when the endpoint declines to hand out a link at all. No retry dialog appears, which is right -- retrying cannot help until the counter resets.

Known cosmetic wart: the server's message ends with a colon introducing an upsell list that is not in the JSON, so it reads as trailing off. Trimming it was tried and rejected -- the text contains no sentence-ending punctuation (the only candidate is the ":(" smiley), so any rule general enough to catch it also eats the whole message.

Verified against the exact body captured from a device.