### PR TITLE
Stop auto-discovery selecting a mirror whose health check failed

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -254,10 +254,15 @@ function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
                     end
 
                     -- early return
-                    if success and not first_working_url then
+                    -- `success` only says the probe ran and returned something. Api.healthCheck reports a
+                    -- dead mirror by RETURNING { success = false }, which is a perfectly successful task,
+                    -- so the health check's own verdict has to be read too -- exactly as the item display
+                    -- above does. Without it the first probe to come back wins, and a mirror that fails
+                    -- instantly (NXDOMAIN answers in ~30ms) beats every mirror that actually works.
+                    if success and result.success and not first_working_url then
                         first_working_url = seed.url
                         -- return true to break all subsequent tasks
-                        if not is_interactive then return true end 
+                        if not is_interactive then return true end
                     end
                     return false
                 end,
@@ -317,7 +322,11 @@ function Zlibrary:autoDiscoverAndSetBaseUrl(is_interactive, retry_callback)
                                 -- queue-jump detection
                                 self.discover_channel:pushTask(health_check_task, function(success, res)
                                     if type(res) ~= "table" then res = {} end
-                                    local status = success and string.format("\u{2714} %dms", res.elapsed or 0) or ("\u{2718} " .. tostring(res.error or ""))
+                                    -- Same as on_item_end: a returned { success = false } is a successful
+                                    -- task reporting a dead mirror, so both have to hold for a tick.
+                                    local status = (success and res.success)
+                                        and string.format("\u{2714} %dms", res.elapsed or 0)
+                                        or ("\u{2718} " .. tostring(res.error or ""))
                                     real = Config.getCacheRealUrl()
                                     local final_info = string.format(" %s \n %s", status, real and (T("Mirror site redirected to: ") .. real) or "")
                                     if dlg then


### PR DESCRIPTION
Auto-discovery would sometimes settle on z-library.rs, which does not resolve at all.

Api.healthCheck reports a dead mirror by RETURNING { success = false, error = ... }. That is a table, so as far as the channel is concerned the probe ran perfectly: deliver_result only sets its own success = false when the task itself failed or returned false outright. on_item_end then gets success = true for a mirror that answered nothing, and picked it.

Which mirror you got was a race, and the race was rigged: the first probe to return wins, and a mirror that fails instantly returns first. z-library.rs answers NXDOMAIN in about 30ms while a working mirror needs a couple of seconds to complete a real request, so the deadest seed in the list beat all nine live ones. That is why it was reproducible rather than occasional.

Read the health check's own verdict as well, which is exactly what the tick or cross beside each item in the list already does two lines above -- the display and the selection disagreed, so the list would show z-library.rs as failed while discovery had already chosen it.

The same confusion set the status in the base URL menu, showing a tick and a response time for a mirror that had just failed; fixed alongside. The cached path was already correct.

Verified by replaying the seeds and timings from a real crash.log: the old condition picks z-library.rs, the new one picks the fastest mirror that actually passed, and when every mirror is dead it now selects nothing rather than the fastest corpse.