### PR TITLE
Select the update archive by name rather than position

### DIFF
--- a/zlibrary/ota.lua
+++ b/zlibrary/ota.lua
@@ -66,6 +66,31 @@ local function getCurrentPluginVersion(plugin_base_path)
     end
 end
 
+-- The release workflow publishes zlibrary_plugin_v<version>.zip. Pick the update archive out of the
+-- release by name: a release can carry more than one asset -- a second archive, a checksum, a
+-- signature -- and the API does not promise any particular order, so taking the first one means a
+-- future asset could silently redirect the updater at the wrong file. Fall back to any zip, so
+-- renaming the artefact cannot strand everyone on an old version with no way to update.
+local UPDATE_ASSET_NAME_PATTERN = "^zlibrary_plugin_.*%.zip$"
+
+local function selectUpdateAsset(assets)
+    if type(assets) ~= "table" then return nil end
+
+    local first_zip
+    for _, asset in ipairs(assets) do
+        if type(asset) == "table" and type(asset.name) == "string"
+                and type(asset.browser_download_url) == "string" then
+            if asset.name:match(UPDATE_ASSET_NAME_PATTERN) then
+                return asset
+            end
+            if not first_zip and asset.name:match("%.zip$") then
+                first_zip = asset
+            end
+        end
+    end
+    return first_zip
+end
+
 local function isVersionOlder(version1, version2)
     if not version1 or not version2 then return false end
 
@@ -277,14 +302,16 @@ function Ota.startUpdateProcess(plugin_path_from_main)
         return
     end
 
-    if not assets[1] or type(assets[1]) ~= "table" or not assets[1].browser_download_url then
-        logger.warn("Zlibrary:Ota.startUpdateProcess - No download URL found in the first release asset.")
+    local asset = selectUpdateAsset(assets)
+    if not asset then
+        logger.warn("Zlibrary:Ota.startUpdateProcess - No update archive among the release assets.")
         _show_ota_final_message(T("Could not find a download link for the update."), true)
         return
     end
 
-    local download_url = assets[1].browser_download_url
-    local asset_name = assets[1].name or "zlibrary_plugin_update.zip"
+    local download_url = asset.browser_download_url
+    local asset_name = asset.name
+    logger.info("Zlibrary:Ota.startUpdateProcess - Selected release asset: " .. asset_name)
 
     local current_version = getCurrentPluginVersion(plugin_path_from_main)
     if not current_version then


### PR DESCRIPTION
The updater took assets[1] and downloaded whatever it found there, without looking at the name. A release carries one asset today, so this works -- but it means the update path depends on the GitHub API returning assets in a particular order, which it does not promise.

Anything added to a release would inherit the updater: a checksum, a signature, or a second archive packaged for plugin managers. If it landed at index 1, every user's update would download the wrong file and unzip it into KOReader's data directory. The failure is silent and self-perpetuating -- the plugin would be installed to the wrong place, so there would be no working updater left to fix it with.

Match zlibrary_plugin_*.zip, which is what the release workflow builds, and fall back to any zip so that renaming the artefact cannot strand users on an old version instead. Refuse rather than guess when no archive is present.

Verified against the live v1.0.36 release: the selector picks exactly what assets[1] picks today, so this changes nothing until a release carries more than one asset -- which is the point.