### PR TITLE
Stop prefetching comments for every visible book

### DIFF
--- a/zlibrary/menu.lua
+++ b/zlibrary/menu.lua
@@ -141,8 +141,13 @@ function M:_updateCoverItems(select_number, no_recalculate_dimen)
                 end
             end
             if item and item.book_id and item.hash then
+                -- Warm the book-details cache: tapping a cover to open a book is the common next
+                -- action, so this usually pays off. Comments are NOT prefetched: they are only seen
+                -- when the user explicitly opens the comments view, so prefetching them for every
+                -- visible item on every page settle was mostly wasted requests -- and on a slow
+                -- mirror those doomed background fetches stall for the full timeout and crowd out the
+                -- foreground calls. fetchAndDisplayComments loads them on demand when actually opened.
                 PreLoader.getBookDetails(item.book_id, item.hash)
-                PreLoader.getBookComments(item.book_id, item.hash)
             end
         end
 


### PR DESCRIPTION
On every cover-page settle the menu prefetched book details AND comments for every visible item -- up to 2N background API calls into a 2-worker channel. A device log on a flaky mirror was dominated by these: of ten API-host timeouts, eight were speculative prefetch and five of those were comments. Comments are only ever shown when the user explicitly opens the comments view, so prefetching one per visible item on every settle was mostly wasted, and on a slow host each doomed fetch stalled for the full block timeout while crowding out the search and download the user actually asked for.

Drop the comments prefetch; keep details, since tapping a cover to open a book is the likely next action and warming that cache usually pays off. Nothing breaks: fetchAndDisplayComments already loads comments on demand with a loading message when the cache is cold (main.lua), so opening a book's comments still works -- it just fetches then instead of ahead of time.