### PR TITLE
Remove the stray semicolon from the comments stylesheet

### DIFF
--- a/zlibrary/bookdetails_dialog.lua
+++ b/zlibrary/bookdetails_dialog.lua
@@ -635,7 +635,7 @@ function BookDetailsDialog:_renderComments(book_comments)
     end
 
     local rendered_html = generateCommentsHTML(book_comments)
-    local COMMENTS_CSS = "@page { margin: 0; };body{padding-top:0;}.comment-node{margin-top:0.8em;margin-bottom:0.8em;}.comment-reply{border-left:2px solid #ccc;padding-left:1em;}.comment-inner{padding-bottom:0.8em;border-bottom:1px solid #e0e0e0;}.comment-header{font-weight:bold;margin-bottom:0.5em;color:#333;}.comment-body{margin-bottom:0.5em;line-height:1.4;word-break:break-word;}.comment-meta{font-size:0.85em;color:#666;font-style:italic;}"
+    local COMMENTS_CSS = "@page { margin: 0; } body{padding-top:0;}.comment-node{margin-top:0.8em;margin-bottom:0.8em;}.comment-reply{border-left:2px solid #ccc;padding-left:1em;}.comment-inner{padding-bottom:0.8em;border-bottom:1px solid #e0e0e0;}.comment-header{font-weight:bold;margin-bottom:0.5em;color:#333;}.comment-body{margin-bottom:0.5em;line-height:1.4;word-break:break-word;}.comment-meta{font-size:0.85em;color:#666;font-style:italic;}"
     return rendered_html, COMMENTS_CSS 
 end
 


### PR DESCRIPTION
The comments CSS began "@page { margin: 0; };body{...}". The semicolon after the @page rule's closing brace is invalid -- CSS expects the next selector there -- so KOReader's renderer logged "css syntax error: expected selector" and dropped the rest of the stylesheet, rendering the comments unstyled. Drop the semicolon so the body rule and the .comment-* rules that follow it are parsed.