### PR TITLE
Stop prefetching book details for every visible book

### DIFF
--- a/zlibrary/menu.lua
+++ b/zlibrary/menu.lua
@@ -140,15 +140,13 @@ function M:_updateCoverItems(select_number, no_recalculate_dimen)
                     added_hashes[item.hash] = true
                 end
             end
-            if item and item.book_id and item.hash then
-                -- Warm the book-details cache: tapping a cover to open a book is the common next
-                -- action, so this usually pays off. Comments are NOT prefetched: they are only seen
-                -- when the user explicitly opens the comments view, so prefetching them for every
-                -- visible item on every page settle was mostly wasted requests -- and on a slow
-                -- mirror those doomed background fetches stall for the full timeout and crowd out the
-                -- foreground calls. fetchAndDisplayComments loads them on demand when actually opened.
-                PreLoader.getBookDetails(item.book_id, item.hash)
-            end
+            -- Book details and comments are deliberately NOT prefetched here. Doing so fired one
+            -- request per visible item on every page settle -- a burst of ~14 speculative calls to
+            -- the API for books the reader mostly never opens. Device logs showed the z-library API
+            -- tarpitting that burst (15s stalls, independent of mirror or wifi), which is the server
+            -- defending a free service against exactly this. Both load on demand instead: book
+            -- details when a cover is tapped, comments when the comments view is opened. Covers still
+            -- prefetch because they come from a separate CDN and are what the grid actually displays.
         end
 
         if #missing_covers == 0 then


### PR DESCRIPTION
The cover menu prefetched book details for every visible item on every page settle -- a burst of ~14 speculative API requests per page for books the reader mostly never opens. Device logs across two mirrors and both a good and a bad wifi showed the z-library API tarpitting that burst: the /eapi/book/{id}/{hash} requests stalled for the full 15s timeout while search, comments, and CDN cover downloads on the same host at the same moment all succeeded. The stall rate did not track the network, which points at the server throttling the burst -- reasonable behaviour for a free, donation-run service defending itself against exactly this pattern.

The prefetch was never load-bearing: it only warmed a cache. Tapping a book already fetches its details on demand (a single request, which works fine), so dropping the prefetch trades pre-warming for a brief spinner on open and, in return, stops hammering the API with requests for books nobody asked for. This mirrors the earlier removal of the comments prefetch; covers stay, since they are the grid's actual content and come from a separate CDN.