### PR TITLE
Remove test mode

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -561,22 +561,6 @@ function Zlibrary:addToMainMenu(menu_items)
                                             Cache:new{ name = "_domains_cache" }:clear()
                                             Ui.showInfoMessage(T("Runtime cache cleared."))
                                         end,
-                                    }, {
-                                        text = T("Test mode"),
-                                        keep_menu_open = true,
-                                        checked_func = function()
-                                            return Config.isTestModeEnabled()
-                                        end,
-                                        callback = function()
-                                            local is_enabled = Config.isTestModeEnabled()
-                                            if is_enabled then
-                                                Config.setTestMode(false)
-                                                Ui.showInfoMessage(T("Test mode disabled. Normal download behavior restored."))
-                                            else
-                                                Config.setTestMode(true)
-                                                Ui.showInfoMessage(T("Test mode enabled. Downloads will always succeed."))
-                                            end
-                                        end,
                                     },
                                 }
                             end

--- a/zlibrary/api.lua
+++ b/zlibrary/api.lua
@@ -561,12 +561,6 @@ end
 function Api.downloadBook(download_url, target_filepath, user_id, user_key, referer_url, progress_callback)
     logger.info(string.format("Zlibrary:Api.downloadBook - START - URL: %s, Target: %s", download_url, target_filepath))
 
-    if Config.isTestModeEnabled() then
-        logger.info("Zlibrary:Api.downloadBook - Test mode enabled, creating fake successful download")
-        logger.info(string.format("Zlibrary:Api.downloadBook - END (Test mode success) - Target: %s", target_filepath))
-        return { success = true, error = nil }
-    end
-
     local result = { success = false, error = nil }
 
     -- Download into a sibling temp file and rename onto target_filepath only once the whole body has

--- a/zlibrary/config.lua
+++ b/zlibrary/config.lua
@@ -551,14 +551,6 @@ function Config.setTurnOffWifiAfterDownload(turn_off)
     Config.saveSetting(Config.SETTINGS_TURN_OFF_WIFI_AFTER_DOWNLOAD_KEY, turn_off)
 end
 
-function Config.isTestModeEnabled()
-    return Config.getSetting("zlibrary_test_mode", false)
-end
-
-function Config.setTestMode(enabled)
-    Config.saveSetting("zlibrary_test_mode", enabled)
-end
-
 -- Timeout configuration functions
 function Config.getTimeoutConfig(timeout_key, default_timeout)
     local saved_timeout = Config.getSetting(timeout_key)


### PR DESCRIPTION
Test mode was a user-facing menu toggle that made Api.downloadBook fake a successful download -- return success, write no file, make no request. Someone asked for a warning when it's on, which is the tell: it was a developer testing aid that leaked into the user menu with an inviting, misleading label ("Downloads will always succeed"). A user fighting real download failures is exactly who would enable it hoping for a fix, then get phantom successes with no book on disk.

Rather than warn about a footgun, remove it. It isn't used, and its purpose -- exercising the download flow without spending quota -- is covered by the test harnesses now. Three sites gone: the menu toggle (main.lua), isTestModeEnabled/setTestMode (config.lua), and the short-circuit in downloadBook (api.lua). The now-unused "Test mode..." translation strings will drop out on the next .pot regeneration; an existing user's saved zlibrary_test_mode setting is simply ignored.

fixes #116 