### PR TITLE
Stop logging every cover fetch at info level

### DIFF
--- a/zlibrary/api.lua
+++ b/zlibrary/api.lua
@@ -642,7 +642,10 @@ function Api.downloadBook(download_url, target_filepath, user_id, user_key, refe
 end
 
 function Api.downloadBookCover(download_url, target_filepath)
-    logger.info(string.format("Zlibrary:Api.downloadBookCover - START - URL: %s, Target: %s", download_url, target_filepath))
+    -- dbg, not info: a page of results fetches dozens of covers, and a START/END pair each buried
+    -- everything else in the log. Api.makeHttpRequest already logs its own START at dbg, so this
+    -- matches. Failures below stay at err, and are the part worth seeing.
+    logger.dbg(string.format("Zlibrary:Api.downloadBookCover - START - URL: %s, Target: %s", download_url, target_filepath))
     local result = { success = false, error = nil }
     local file, err_open = io.open(target_filepath, "wb")
     if not file then
@@ -683,7 +686,7 @@ function Api.downloadBookCover(download_url, target_filepath)
         return result
     end
 
-    logger.info("Zlibrary:Api.downloadBookCover - END (Success)")
+    logger.dbg("Zlibrary:Api.downloadBookCover - END (Success)")
     result.success = true
     return result
 end


### PR DESCRIPTION
Api.downloadBookCover logged a START and an END (Success) line for each cover. A page of results fetches dozens, so ~60 lines per page went into the log, burying everything else in it -- searches, downloads and the errors worth reading.

Drop both to dbg. That matches Api.makeHttpRequest, which already logs its own START at dbg, so the inconsistency was the anomaly rather than the change. The four failure paths stay at err: a cover that does not load is the part worth seeing, and it is rare enough to be worth a line.

Nothing is lost for diagnosis -- enabling verbose logging brings the pair back, which is exactly when someone would want them.