### PR TITLE
Keep 1lib.sk in the seed list

### DIFF
--- a/zlibrary/config.lua
+++ b/zlibrary/config.lua
@@ -161,7 +161,11 @@ Config.SEED_URLS = { -- List of known Z-library base URLs extracted from the And
     "https://lib-africa.sk/",
     "https://z-library.do/",
     "https://z-lib.gd/",
-    -- "https://1lib.sk/", -- July 2026: behind a DiamWall browser check, so the API is unreachable
+    "https://1lib.sk/", -- July 2026: behind a DiamWall browser check the plugin cannot pass, so
+                        -- the API is unreachable. Left in the list because that is the operator's
+                        -- setting of the day, not a property of the domain: discovery health-checks
+                        -- it, fails it in two requests and moves on, and it starts working again by
+                        -- itself if the check is ever lifted.
     "https://z-lib.gl/",
     "https://z-library.rs/", -- these last 3 don't seem to work currently (May 2026), but may be worth trying in the future
     "https://z-lib.do/",


### PR DESCRIPTION
Commenting it out treated a browser check as a property of the domain. It is not -- it is what the operator has switched on this month, and it can be switched off again just as easily. A commented-out entry is one nobody ever re-tests, so the mirror would stay dropped long after it started working.

Left active with a note instead, which is how z-library.rs and its neighbours are already handled here. Nothing hammers it in the meantime: discovery health-checks it, the challenge is recognised in two requests, and it is passed over. If the check is ever lifted the mirror simply starts working again.