### PR TITLE
Show the Telugu language name in a script that renders

### DIFF
--- a/zlibrary/config.lua
+++ b/zlibrary/config.lua
@@ -116,7 +116,9 @@ Config.SUPPORTED_LANGUAGES = {
     { name = "Русский", value = "russian" },
     { name = "Српски", value = "serbian" },
     { name = "Español", value = "spanish" },
-    { name = "తెలుగు", value = "telugu" },
+    -- Latin, unlike its neighbours: KOReader bundles no font covering Telugu, so the native
+    -- name renders as six empty boxes. A name that can be read beats one that cannot.
+    { name = "Telugu", value = "telugu" },
     { name = "ไทย", value = "thai" },
     { name = "繁體中文", value = "traditional chinese" },
     { name = "Türkçe", value = "turkish" },


### PR DESCRIPTION
Every other entry in the search-language list is written in its own script and every other one has a font behind it. Telugu does not: KOReader bundles no face covering U+0C00-U+0C7F, and Font.fallbacks has nothing to fall back to, so "తెలుగు" drew as six empty boxes on a stock install.

Latin is the lesser evil. A user who reads Telugu can still recognise "Telugu"; nobody can read a row of boxes.

Found by widening the glyph coverage check to literal UTF-8 rather than only \u{...} escapes. Of the twenty-odd non-Latin names in that list this is the only one uncovered -- Arabic, Georgian, Hindi, Thai, Urdu, Bengali, Armenian and the CJK entries all resolve.