### PR TITLE
Add the transport harnesses to the repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,12 +153,15 @@ jobs:
             echo "Info: 'l10n' directory not found. Skipping files from 'l10n'."
           fi
 
-          # Add README*.md *.md if it exists and is a file
+          # Add README*.md *.md if it exists and is a file.
+          # test/ is excluded: the harnesses there are for developing the plugin, not for running
+          # it, and at -maxdepth 2 test/README.md would otherwise be shipped to every user. The
+          # .lua finds above are already scoped tightly enough that no test code can reach the zip.
           while IFS= read -r -d $'\0' md_file; do
             if [ -f "$md_file" ]; then
               FILE_LINES="${FILE_LINES}${md_file}"$'\n'
             fi
-          done < <(find . -maxdepth 2 -type f -name '*.md' -print0)
+          done < <(find . -maxdepth 2 -type f -name '*.md' -not -path './test/*' -print0)
           
           # Add LICENSE if it exists and is a file
           if [ -f "LICENSE" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 scripts/
 .DS_Store
 .vscode/
+# Python bytecode from the test harnesses
+__pycache__/
+*.pyc

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,102 @@
+# Harnesses
+
+Regression tests for the parts of the plugin that are awkward to check by hand: the HTTP
+transport, the retry dialog, the gettext shim, and the glyphs the UI asks fonts for. They run
+offline against a scripted server, so they need no z-library account, no network, and no device.
+
+```sh
+./test/run.sh              # everything
+./test/run.sh redirect     # only harnesses whose name matches
+```
+
+Exits non-zero if anything fails, so it works as a pre-push check.
+
+## Requirements
+
+A **built KOReader checkout**. The plugin targets KOReader's LuaJIT, which is Lua 5.1, and the
+harnesses themselves use `loadstring` and `setfenv` to compile file-local functions out of the
+source — neither exists in a system Lua 5.4, so running there produces failures that say nothing
+about the plugin. The harnesses also borrow KOReader's LuaSocket for real URL parsing and its
+bundled fonts for the glyph check.
+
+Point `run.sh` at yours in whichever way suits. It takes the first that applies:
+
+1. `KOREADER_DIR` in the environment, for a one-off:
+   ```sh
+   KOREADER_DIR=/path/to/koreader ./test/run.sh
+   ```
+2. `scripts/test-env.sh`, for a path you do not want to keep retyping:
+   ```sh
+   echo 'KOREADER_DIR="$HOME/src/koreader"' > scripts/test-env.sh
+   ```
+   `scripts/` is gitignored, so this stays on your machine and out of the repository. The file
+   is sourced by `run.sh`, so it is shell, not a config format.
+3. Failing both, it looks in `~/Documents/Dev/koreader-git`, `~/koreader`, and beside this
+   repository.
+
+If none of those find a build, `run.sh` says so and exits 2 rather than failing obscurely.
+
+## What each one covers
+
+| Harness | Covers |
+| --- | --- |
+| `redirect_resolve_harness.lua` | Which `Location` shapes resolve, and to what. Relative, root-relative, protocol-relative, same-host, cross-host, 301/302/303/307/308. Also that `real_url_base` — the signal that pins a new base URL — is set only for a genuine cross-host move. |
+| `redirect_follow_harness.lua` | What `makeHttpRequest` does with them: multi-hop chains, POST body replay, method conversion per RFC, loop termination, cookie handling, and that `onRedirect` still owns mirror moves. |
+| `bot_challenge_harness.lua` | Recognising a "verifying your browser" interstitial, and — as importantly — not mistaking a JSON API error, an nginx error page, or a book description for one. |
+| `retry_message_harness.lua` | That the dialog classifies a failure from the raw error string, opens for the kinds it should, offers auto-discovery only where switching mirrors would help, and says something true and distinct for each. |
+| `getplural_harness.lua` | That loading the plugin's catalogue leaves KOReader's own gettext globals as it found them. |
+| `timeout_keys_harness.lua` | That every `operation_key` at a call site resolves to a real timeout getter. A typo yields no hint rather than an error, which is invisible at runtime. |
+| `glyph_coverage_check.py` | That every non-ASCII codepoint the plugin can display — `\u{...}` escapes and literal UTF-8 alike — maps to a real glyph in some bundled font. Excludes U+FFF1–FFF3, which are `textboxwidget` control markers rather than glyphs. |
+
+## Conventions
+
+Each `*_harness.lua` is invoked as `luajit <harness> <plugin-root> <luasocket-src>` and each
+`*_check.py` as `python3 <check> <plugin-root> <koreader-root>`. Drop a new file matching either
+pattern into this directory and `run.sh` picks it up.
+
+`support.lua` holds the shared pieces: the pass/fail reporter, the KOReader module stubs, and
+`extract_function` / `extract_block`.
+
+Those last two are the important convention. Several of the functions under test are file-local
+and cannot be required, so the harnesses **pull them out of the source and compile them** rather
+than working from a copy. A copied function keeps passing after the original changes, which is
+the failure mode that matters most here — a green suite that is no longer testing the shipped
+code.
+
+## Why these exist
+
+Each was written against a real bug, and each fails against the commit before its fix:
+
+- Two users reported `HTTP Error: 307` on sign-in. Only absolute cross-host redirects were
+  followed, so an ordinary `http` → `https` hop on the same host was refused.
+- Fixing that introduced a worse bug: a mirror redirecting to itself was chased five times,
+  taking seconds and five requests against a free service, where the old code failed in one.
+- A POST replayed across a redirect sent an empty body while still advertising the original
+  `Content-Length` — the server would have seen a blank sign-in with nothing in any log to say
+  why.
+- The api layer produced a correct, actionable error for a walled mirror and the dialog
+  discarded it, telling users the failure was "temporary" when it was permanent. The redirect
+  harnesses could not catch that: it lived one layer up, in `ui.lua`.
+- Two icons pointed at codepoints no bundled font carries and drew as empty boxes. A third
+  turned up when this check was widened to literal UTF-8: the Telugu language name in the
+  search-language list, which no bundled font covers at all.
+- A walled mirror was reported as a bare `HTTP Error: 513` instead of a message naming the host
+  and pointing at another server.
+- Loading the plugin's catalogue left KOReader's own gettext globals altered: its plural
+  selector kept running the rule from the plugin's `.mo` for the rest of the session.
+
+## Not covered
+
+Known gaps, listed so the suite is not mistaken for more than it is:
+
+- **A live mirror.** The network is stubbed throughout, so nothing here shows the plugin works
+  against a real server. That still needs a device and an account.
+- **`retry_on_stall`.** The retry-once-on-a-silent-server path in `makeHttpRequest` has no
+  coverage; every guard in it could be deleted with the suite still green.
+- **The redirect-target cache** in `config.lua` (`setCacheRealUrl`, `clearCacheRealUrlIfPinned`,
+  the TTL). The harnesses stub it, so only the fact that pinning is *called* is checked, not
+  that it stores or expires correctly.
+- **A caller-supplied `options.source`.** Bodies are replayed correctly when passed as
+  `options.body`; a caller passing a raw ltn12 source would still have it drained on the first
+  attempt and send an empty body on a retry. Nothing currently does, and nothing stops it.
+- **CI.** These do not run there, as the runner needs a built KOReader checkout.

--- a/test/bot_challenge_harness.lua
+++ b/test/bot_challenge_harness.lua
@@ -1,0 +1,105 @@
+-- Does the plugin recognise a bot-check page, and not mistake anything else for one?
+--
+-- Some mirrors sit behind a service that answers an API call with a "verifying your browser"
+-- interstitial instead of JSON. There is no way past it here -- it wants a browser to run its
+-- JavaScript -- so the useful behaviour is to say so and let the caller offer auto-discovery,
+-- rather than report a bare "HTTP Error: 513" that tells the user nothing.
+--
+-- The false-positive cases matter as much as the positive one: branding a working mirror as
+-- blocked would push users away from a server that was about to answer them.
+--
+-- The positive fixture is the real body captured from 1lib.sk in July 2026.
+
+local PLUGIN = assert(arg[1], "usage: luajit bot_challenge_harness.lua <plugin-root> <luasocket-src>")
+local LUASOCKET = assert(arg[2], "usage: luajit bot_challenge_harness.lua <plugin-root> <luasocket-src>")
+
+package.path = PLUGIN .. "/?.lua;" .. package.path
+local support = dofile(PLUGIN .. "/test/support.lua")
+support.preload_socket(LUASOCKET)
+support.preload_koreader_stubs()
+local r = support.reporter()
+
+package.preload["zlibrary.config"] = function()
+    return {
+        setCacheRealUrl = function() end,
+        getCacheRealUrl = function() return nil end,
+        clearCacheRealUrlIfPinned = function() return false end,
+    }
+end
+
+local DIAMWALL_BODY = [[<html><head>
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<link rel="icon" type="image/x-icon" href="https://cdn.diamwall.com/cdn-cgi/static/img/favicon/favicon.ico">
+<title>Verifying your browser | DiamWall</title>
+</head><body style="margin:0px;padding:0px;overflow:hidden">
+<iframe src="/.well-known/diamwall/load/html/5s.html" frameborder="0" id="verification"></iframe>
+<script>
+document.cookie="dwid=705a24e5b672def409d8d8dfbfc08352; path=/; domain="+location.hostname;
+</script>
+<script src="/cdn-cgi/mitigation/v2/chl/chlb.lib?bdt=0&b12=0&brc=0" defer></script>
+</body></html>]]
+
+local serve
+package.preload["socket.http"] = function()
+    return { request = function(p) return serve(p) end }
+end
+local Api = require("zlibrary.api")
+
+-- ---------------------------------------------------------------- the observed sequence
+-- 307 with a Set-Cookie, then 513 carrying the challenge page once the cookie is returned.
+local n = 0
+serve = function(p)
+    n = n + 1
+    if n == 1 then
+        return 1, 307, { location = p.url, ["set-cookie"] = "dwid=abc; Path=/" }, "HTTP/1.1 307"
+    end
+    if p.sink then p.sink(DIAMWALL_BODY) end
+    return 1, 513, {}, "HTTP/1.1 513 "
+end
+local res = Api.makeHttpRequest{ url = "https://1lib.sk/eapi/user/login", method = "GET", headers = {} }
+r.check("challenge recognised, not reported as a bare status",
+        res.error and res.error:find("refusing automated access", 1, true) ~= nil,
+        "error=" .. tostring(res.error))
+r.check("error names the host so the user can act",
+        res.error and res.error:find("1lib.sk", 1, true) ~= nil, tostring(res.error))
+r.check("error says what to do about it",
+        res.error and res.error:find("different Z%-library server") ~= nil, tostring(res.error))
+r.check("bounded: 2 requests, no hammering", n == 2, "made " .. n)
+
+-- ---------------------------------------------------------------- must not misfire
+n = 0
+serve = function(p)
+    n = n + 1
+    if p.sink then p.sink('{"success":0,"error":"Incorrect email or password"}') end
+    return 1, 401, {}, "HTTP/1.1 401"
+end
+res = Api.makeHttpRequest{ url = "https://good.example/eapi/user/login", method = "GET", headers = {} }
+r.check("a JSON API error is not misread as a challenge",
+        res.error and res.error:find("refusing automated access", 1, true) == nil,
+        tostring(res.error))
+
+n = 0
+serve = function(p)
+    n = n + 1
+    if p.sink then p.sink("<html><head><title>502 Bad Gateway</title></head><body>nginx</body></html>") end
+    return 1, 502, {}, "HTTP/1.1 502"
+end
+res = Api.makeHttpRequest{ url = "https://good.example/eapi/user/login", method = "GET", headers = {} }
+r.check("an ordinary HTML error page is not misread as a challenge",
+        res.error and res.error:find("refusing automated access", 1, true) == nil,
+        tostring(res.error))
+
+-- A book whose description happens to quote a challenge phrase must not poison a good response.
+n = 0
+serve = function(p)
+    n = n + 1
+    if p.sink then p.sink('{"success":1,"book":{"title":"Verifying your browser: a history"}}') end
+    return 1, 200, {}, "HTTP/1.1 200"
+end
+res = Api.makeHttpRequest{ url = "https://good.example/eapi/book/1", method = "GET", headers = {} }
+r.check("a successful response is never inspected for challenge markers",
+        res.status_code == 200 and res.error == nil,
+        "status=" .. tostring(res.status_code) .. " error=" .. tostring(res.error))
+
+r.finish()

--- a/test/getplural_harness.lua
+++ b/test/getplural_harness.lua
@@ -1,0 +1,104 @@
+-- Does loading the plugin's gettext shim leave KOReader's global getPlural clobbered?
+--
+-- KOReader rebuilds GetText.getPlural from the catalogue's Plural-Forms header every
+-- changeLang (frontend/gettext.lua:220). The shim points GetText.dirname at the plugin's
+-- own l10n and calls changeLang to parse it, then restores the fields it saved. If
+-- getPlural is not among them, KOReader keeps using the plural rule from the PLUGIN's
+-- catalogue for the rest of the session.
+--
+-- usage: luajit getplural_harness.lua <plugin-root> <luasocket-src>
+
+local PLUGIN = assert(arg[1], "usage: luajit getplural_harness.lua <plugin-root> <luasocket-src>")
+local target = PLUGIN .. "/zlibrary/gettext.lua"
+
+-- ---------------------------------------------------------------- stubs
+local KOREADER_PLURAL = function(n) return n == 1 and 0 or 1 end   -- sentinel we must get back
+local PLUGIN_PLURAL   = function(n) return 0 end                   -- what our catalogue would install
+
+local GetText
+GetText = {
+    dirname = "l10n",
+    textdomain = "koreader",
+    context = { koreader_ctx = { hello = "hallo" } },
+    translation = { ["KOReader string"] = "KOReader vertaling" },
+    current_lang = "nl_NL",
+    getPlural = KOREADER_PLURAL,
+    wrapUntranslated = function(t) return t end,
+    -- Simulates frontend/gettext.lua changeLang: wipes both tables, sets current_lang,
+    -- and rebuilds getPlural from the newly-parsed header.
+    changeLang = function(new_lang)
+        GetText.context = {}
+        GetText.translation = { ["Plugin string"] = "Plugin vertaling" }
+        GetText.current_lang = new_lang
+        GetText.getPlural = PLUGIN_PLURAL
+        return true
+    end,
+}
+
+package.preload["gettext"] = function() return GetText end
+package.preload["logger"] = function()
+    return { warn = function() end, info = function() end, dbg = function() end }
+end
+package.preload["util"] = function()
+    return {
+        splitFilePathName = function(p) return p:match("^(.*/)([^/]*)$") end,
+        tableDeepCopy = function(t)
+            local function copy(v, seen)
+                if type(v) ~= "table" then return v end
+                if seen[v] then return seen[v] end
+                local out = {}
+                seen[v] = out
+                for k, val in pairs(v) do out[copy(k, seen)] = copy(val, seen) end
+                return setmetatable(out, getmetatable(v))
+            end
+            return copy(t, {})
+        end,
+    }
+end
+
+G_reader_settings = { readSetting = function() return "nl_NL" end }
+
+-- ---------------------------------------------------------------- run
+local before = GetText.getPlural
+assert(before == KOREADER_PLURAL, "harness setup wrong")
+
+local ok, err = pcall(dofile, target)
+if not ok then
+    print(string.format("  LOAD FAILED: %s", tostring(err)))
+    os.exit(2)
+end
+
+local after = GetText.getPlural
+
+-- ---------------------------------------------------------------- assertions
+local checks = {}
+local function check(name, pass, detail)
+    checks[#checks + 1] = { name = name, pass = pass, detail = detail or "" }
+end
+
+check("GetText.getPlural restored to KOReader's",
+      after == KOREADER_PLURAL,
+      after == PLUGIN_PLURAL and "still the PLUGIN's plural rule -- LEAKED"
+          or (after == KOREADER_PLURAL and "" or "some third function"))
+
+-- The plural rules differ observably, so show the behavioural consequence too.
+check("plural selection for n=5 unchanged",
+      after(5) == KOREADER_PLURAL(5),
+      string.format("KOReader expects %d, global now yields %d", KOREADER_PLURAL(5), after(5)))
+
+-- The fields the shim already restored must stay restored.
+check("GetText.translation restored",
+      GetText.translation["KOReader string"] == "KOReader vertaling",
+      "plugin catalogue left in KOReader's table")
+check("GetText.current_lang restored", GetText.current_lang == "nl_NL", "")
+check("GetText.dirname restored", GetText.dirname == "l10n",
+      "dirname still points at the plugin: " .. tostring(GetText.dirname))
+
+local failed = 0
+for _, c in ipairs(checks) do
+    if not c.pass then failed = failed + 1 end
+    print(string.format("  [%s] %s%s", c.pass and "PASS" or "FAIL", c.name,
+                        (not c.pass and c.detail ~= "") and ("  <- " .. c.detail) or ""))
+end
+print(string.format("  %d/%d passed", #checks - failed, #checks))
+os.exit(failed == 0 and 0 or 1)

--- a/test/glyph_coverage_check.py
+++ b/test/glyph_coverage_check.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Assert every icon the plugin asks for exists in a font KOReader bundles.
+
+A codepoint no bundled font carries renders as a .notdef box on the device, and nothing in Lua,
+in the .po files, or in any other check complains -- the only symptom is a box a human has to
+notice. Two shipped that way: U+F0013 on the author line and U+1F5D8 on "Reset to defaults",
+both plausible-looking Private Use codepoints that simply are not in the fonts.
+
+KOReader resolves a glyph through Font.fallbacks (frontend/ui/font.lua), so "covered" means
+present in ANY bundled face, not just the one the widget asks for.
+
+Covered means mapped to a real glyph. A cmap can list a codepoint inside a segment and still
+resolve it to glyph 0, which is .notdef -- the box itself. An earlier version of this parser
+read only the start and end of each format-4 segment and ignored idDelta/idRangeOffset, so it
+counted those as covered: the one bug a coverage checker must not have.
+
+usage: python3 glyph_coverage_check.py <plugin-root> <koreader-root>
+"""
+import glob
+import os
+import re
+import struct
+import sys
+
+
+def _u16(data, off):
+    return struct.unpack_from(">H", data, off)[0]
+
+
+def _parse_format4(data, sub):
+    """Format 4: segmented mapping. Returns codepoints resolving to a non-zero glyph id."""
+    out = set()
+    seg_x2 = _u16(data, sub + 6)
+    seg = seg_x2 // 2
+    end_off = sub + 14
+    start_off = end_off + seg_x2 + 2          # +2 skips reservedPad
+    delta_off = start_off + seg_x2
+    range_off = delta_off + seg_x2
+
+    for i in range(seg):
+        end = _u16(data, end_off + i * 2)
+        start = _u16(data, start_off + i * 2)
+        delta = _u16(data, delta_off + i * 2)
+        range_offset = _u16(data, range_off + i * 2)
+        if start > end or start == 0xFFFF:
+            continue
+        for c in range(start, min(end, 0xFFFE) + 1):
+            if range_offset == 0:
+                gid = (c + delta) & 0xFFFF
+            else:
+                # The offset is measured from the idRangeOffset slot itself, which is why the
+                # segment's own position is added back in.
+                addr = range_off + i * 2 + range_offset + (c - start) * 2
+                if addr + 1 >= len(data):
+                    continue
+                gid = _u16(data, addr)
+                if gid != 0:
+                    gid = (gid + delta) & 0xFFFF
+            if gid != 0:
+                out.add(c)
+    return out
+
+
+def _parse_format12(data, sub):
+    """Format 12: segmented coverage reaching beyond the BMP."""
+    out = set()
+    ngroups = struct.unpack_from(">I", data, sub + 12)[0]
+    for g in range(ngroups):
+        go = sub + 16 + g * 12
+        start, end, start_gid = struct.unpack_from(">III", data, go)
+        if start_gid == 0 or end < start or end - start > 0x20000:
+            continue
+        out.update(range(start, end + 1))
+    return out
+
+
+def font_codepoints(path):
+    """Codepoints a font maps to a real glyph. Handles cmap formats 4 and 12, and .ttc."""
+    try:
+        with open(path, "rb") as fh:
+            data = fh.read()
+    except OSError:
+        return set()
+    try:
+        off = struct.unpack_from(">I", data, 12)[0] if data[:4] == b"ttcf" else 0
+        num = _u16(data, off + 4)
+        cmap_off = None
+        for i in range(num):
+            o = off + 12 + i * 16
+            if data[o:o + 4] == b"cmap":
+                cmap_off = struct.unpack_from(">I", data, o + 8)[0]
+        if cmap_off is None:
+            return set()
+
+        out = set()
+        for i in range(_u16(data, cmap_off + 2)):
+            rec = cmap_off + 4 + i * 8
+            sub = cmap_off + struct.unpack_from(">I", data, rec + 4)[0]
+            fmt = _u16(data, sub)
+            if fmt == 4:
+                out |= _parse_format4(data, sub)
+            elif fmt == 12:
+                out |= _parse_format12(data, sub)
+        return out
+    except (struct.error, IndexError):
+        return set()
+
+
+# Not glyphs: KOReader's "poor text formatting" markers, which textboxwidget consumes as control
+# codes and never draws (frontend/ui/widget/textboxwidget.lua:128-130).
+CONTROL = {0xFFF1: "PTF_HEADER", 0xFFF2: "PTF_BOLD_START", 0xFFF3: "PTF_BOLD_END"}
+
+ESCAPE = re.compile(r"\\u\{([0-9A-Fa-f]+)\}")
+
+
+def plugin_codepoints(plugin_root):
+    """Every non-ASCII codepoint the plugin can put on screen from Lua -- \\u{...} escapes and
+    literal UTF-8 alike, since an icon pasted in directly is just as capable of being a box."""
+    wanted = []
+    for lua in sorted(glob.glob(os.path.join(plugin_root, "**/*.lua"), recursive=True)):
+        if os.path.basename(lua) == "zlibrary_credentials.lua" or os.sep + "test" + os.sep in lua:
+            continue
+        rel = os.path.relpath(lua, plugin_root)
+        with open(lua, encoding="utf-8", errors="replace") as fh:
+            for lineno, line in enumerate(fh, 1):
+                for m in ESCAPE.finditer(line):
+                    cp = int(m.group(1), 16)
+                    if cp >= 0x80 and cp not in CONTROL:
+                        wanted.append((rel, lineno, cp, "escape"))
+                for ch in line:
+                    cp = ord(ch)
+                    if cp >= 0x80 and cp not in CONTROL:
+                        wanted.append((rel, lineno, cp, "literal"))
+    return wanted
+
+
+def main(plugin_root, koreader_root):
+    fonts = {}
+    for pat in ("resources/fonts/**/*.ttf", "resources/fonts/**/*.ttc", "resources/fonts/**/*.otf"):
+        for p in glob.glob(os.path.join(koreader_root, pat), recursive=True):
+            fonts[os.path.basename(p)] = font_codepoints(p)
+    if not fonts:
+        print(f"  no fonts under {koreader_root}/resources/fonts")
+        print("  a fresh KOReader clone needs its submodules: git submodule update --init")
+        return 2
+    covered = set().union(*fonts.values())
+    print(f"  {len(fonts)} bundled fonts, {len(covered)} codepoints mapped to a real glyph\n")
+
+    wanted = plugin_codepoints(plugin_root)
+    if not wanted:
+        # The plugin has always had icons. Finding none means the scan broke, not that the
+        # problem went away, and reporting success would be a lie.
+        print("  FAIL: no non-ASCII codepoints found at all -- the scan itself is broken")
+        return 1
+
+    missing, seen = [], set()
+    for rel, lineno, cp, kind in wanted:
+        if cp in covered:
+            continue
+        missing.append((rel, lineno, cp, kind))
+        key = (rel, lineno, cp)
+        if key not in seen:
+            seen.add(key)
+            print(f"  MISSING  U+{cp:04X}  ({kind})  {rel}:{lineno}")
+
+    print(f"\n  {len(wanted) - len(missing)}/{len(wanted)} codepoints covered by a bundled font")
+    return 1 if missing else 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print("usage: python3 glyph_coverage_check.py <plugin-root> <koreader-root>")
+        sys.exit(2)
+    sys.exit(main(sys.argv[1], sys.argv[2]))

--- a/test/redirect_follow_harness.lua
+++ b/test/redirect_follow_harness.lua
@@ -1,0 +1,290 @@
+-- Drives the real Api.makeHttpRequest through a scripted server to check the follow loop.
+--
+-- redirect_resolve_harness proves which Location shapes resolve. This proves what
+-- makeHttpRequest then DOES with them: that it follows more than one hop, that a 307 POST
+-- re-sends its body instead of an empty one, that a 302 POST degrades to GET per RFC, that a
+-- mirror pointing at itself is not chased five times, and that a cookie set by a challenge is
+-- returned to the host that set it and to nowhere else.
+--
+-- The body case is the subtle one. An ltn12 source is a one-shot generator, so a naive re-issue
+-- sends nothing while still advertising the original Content-Length: the server would see a
+-- blank sign-in and reject it, with no clue in any log as to why.
+
+local PLUGIN = assert(arg[1], "usage: luajit redirect_follow_harness.lua <plugin-root> <luasocket-src>")
+local LUASOCKET = assert(arg[2], "usage: luajit redirect_follow_harness.lua <plugin-root> <luasocket-src>")
+
+package.path = PLUGIN .. "/?.lua;" .. package.path
+local support = dofile(PLUGIN .. "/test/support.lua")
+support.preload_socket(LUASOCKET)
+support.preload_koreader_stubs()
+local r = support.reporter()
+
+local pinned = nil
+package.preload["zlibrary.config"] = function()
+    return {
+        setCacheRealUrl = function(_, real) pinned = real end,
+        getCacheRealUrl = function() return pinned end,
+        clearCacheRealUrlIfPinned = function() return false end,
+    }
+end
+
+-- Scripted server: routes keyed by URL, plus a log of every request it actually received.
+local server = { routes = {}, seen = {} }
+local function default_request(params)
+    local body = nil
+    if params.source then
+        local parts = {}
+        while true do
+            local chunk = params.source()
+            if not chunk then break end
+            table.insert(parts, chunk)
+        end
+        body = table.concat(parts)
+    end
+    table.insert(server.seen, {
+        url = params.url, method = params.method, body = body,
+        cookie = params.headers and params.headers["Cookie"],
+        content_length = params.headers and params.headers["Content-Length"],
+        content_type = params.headers and params.headers["Content-Type"],
+    })
+    local route = server.routes[params.url] or { status = 404 }
+    if route.body and params.sink then params.sink(route.body) end
+    return 1, route.status, route.headers or {}, "HTTP/1.1 " .. tostring(route.status)
+end
+
+local http_stub = { request = function(params) return server.handler(params) end }
+package.preload["socket.http"] = function() return http_stub end
+
+local Api = require("zlibrary.api")
+
+local function reset(routes, handler)
+    server.routes, server.seen, pinned = routes or {}, {}, nil
+    server.handler = handler or default_request
+end
+
+local A = "https://a.example/eapi/user/login"
+
+-- ---------------------------------------------------------------- relative 307 keeps the body
+reset({
+    [A] = { status = 307, headers = { location = "/eapi/v2/login" } },
+    ["https://a.example/eapi/v2/login"] = { status = 200, body = "{}" },
+})
+local res = Api.makeHttpRequest{
+    url = A, method = "POST", body = "email=x&password=y",
+    headers = { ["Content-Length"] = "18", ["Content-Type"] = "application/x-www-form-urlencoded" },
+}
+r.check("relative 307: reaches the final URL", res.status_code == 200,
+        "status " .. tostring(res.status_code) .. " error=" .. tostring(res.error))
+r.check("relative 307: two requests made", #server.seen == 2, "made " .. #server.seen)
+r.check("relative 307: method stays POST",
+        server.seen[2] and server.seen[2].method == "POST",
+        server.seen[2] and server.seen[2].method or "no 2nd request")
+r.check("relative 307: body re-sent, not empty",
+        server.seen[2] and server.seen[2].body == "email=x&password=y",
+        server.seen[2] and string.format("%q", tostring(server.seen[2].body)) or "no 2nd request")
+
+-- ---------------------------------------------------------------- multi-hop across hosts
+reset({
+    [A] = { status = 307, headers = { location = "https://b.example/eapi/user/login" } },
+    ["https://b.example/eapi/user/login"] = { status = 307, headers = { location = "https://c.example/eapi/user/login" } },
+    ["https://c.example/eapi/user/login"] = { status = 200, body = "{}" },
+})
+res = Api.makeHttpRequest{ url = A, method = "POST", body = "x=1", headers = {} }
+r.check("two cross-host hops complete", res.status_code == 200,
+        "status " .. tostring(res.status_code) .. " error=" .. tostring(res.error))
+r.check("two cross-host hops: 3 requests", #server.seen == 3, "made " .. #server.seen)
+r.check("two cross-host hops: final base pinned", pinned == "https://c.example", tostring(pinned))
+
+-- ---------------------------------------------------------------- 302 POST degrades to GET
+reset({
+    [A] = { status = 302, headers = { location = "/after" } },
+    ["https://a.example/after"] = { status = 200, body = "{}" },
+})
+res = Api.makeHttpRequest{
+    url = A, method = "POST", body = "email=x",
+    headers = { ["Content-Length"] = "7", ["Content-Type"] = "application/x-www-form-urlencoded" },
+}
+r.check("302 POST becomes GET", server.seen[2] and server.seen[2].method == "GET",
+        server.seen[2] and server.seen[2].method or "no 2nd request")
+r.check("302 POST drops the body", server.seen[2] and server.seen[2].body == nil,
+        server.seen[2] and tostring(server.seen[2].body) or "no 2nd request")
+r.check("302 POST drops Content-Length", server.seen[2] and server.seen[2].content_length == nil,
+        server.seen[2] and tostring(server.seen[2].content_length) or "no 2nd request")
+r.check("302 POST drops Content-Type", server.seen[2] and server.seen[2].content_type == nil,
+        server.seen[2] and tostring(server.seen[2].content_type) or "no 2nd request")
+
+-- 301 and 303 take the same route. Only 302 used to be exercised, while the README claimed
+-- method conversion "per RFC" for all of them.
+for _, status in ipairs({ 301, 303 }) do
+    reset({
+        [A] = { status = status, headers = { location = "/after" } },
+        ["https://a.example/after"] = { status = 200, body = "{}" },
+    })
+    Api.makeHttpRequest{
+        url = A, method = "POST", body = "email=x",
+        headers = { ["Content-Length"] = "7", ["Content-Type"] = "application/x-www-form-urlencoded" },
+    }
+    r.check(status .. " POST becomes GET and drops its body",
+            server.seen[2] and server.seen[2].method == "GET"
+                and server.seen[2].body == nil
+                and server.seen[2].content_length == nil,
+            server.seen[2] and (server.seen[2].method .. " body=" .. tostring(server.seen[2].body))
+                           or "no 2nd request")
+end
+
+-- ---------------------------------------------------------------- loops terminate early
+reset({
+    [A] = { status = 307, headers = { location = "https://b.example/x" } },
+    ["https://b.example/x"] = { status = 307, headers = { location = A } },
+})
+res = Api.makeHttpRequest{ url = A, method = "GET", headers = {} }
+r.check("A<->B loop terminates", res.error ~= nil and res.status_code ~= 200,
+        "error=" .. tostring(res.error))
+r.check("A<->B loop stops at 2 requests", #server.seen == 2, "made " .. #server.seen)
+
+-- The real 1lib.sk shape: a WAF answering with a Location pointing at the request URL. Hopeless
+-- on the first hop, so exactly one request must go out. Chasing it five times only loads a free
+-- service to learn what was already known.
+reset({ [A] = { status = 307, headers = { location = A } } })
+res = Api.makeHttpRequest{ url = A, method = "GET", headers = {} }
+r.check("self-redirect: exactly one request", #server.seen == 1, "made " .. #server.seen)
+r.check("self-redirect: reports too many redirects",
+        res.error and string.find(tostring(res.error), "Too many redirects", 1, true) ~= nil,
+        "error=" .. tostring(res.error))
+
+reset({ [A] = { status = 307, headers = { location = "/eapi/user/login" } } })
+res = Api.makeHttpRequest{ url = A, method = "GET", headers = {} }
+r.check("self-redirect via relative Location: one request", #server.seen == 1, "made " .. #server.seen)
+
+-- A chain of distinct URLs must stop at the hop cap. Without this the bound could be raised to
+-- any value with the suite still green, and a long chain would hammer a free service.
+local chain = {}
+for i = 1, 9 do
+    chain["https://a.example/h" .. i] =
+        { status = 307, headers = { location = "https://a.example/h" .. (i + 1) } }
+end
+reset(chain)
+res = Api.makeHttpRequest{ url = "https://a.example/h1", method = "GET", headers = {} }
+r.check("hop cap reached: chain stops at 6 requests", #server.seen == 6, "made " .. #server.seen)
+r.check("hop cap reached: reported as too many redirects",
+        res.error and string.find(tostring(res.error), "Too many redirects", 1, true) ~= nil,
+        "error=" .. tostring(res.error))
+
+-- A host issuing a fresh cookie every time defeats the loop guard by design, so the hop cap is
+-- the only thing left bounding it.
+local ck = 0
+reset(nil, function(params)
+    ck = ck + 1
+    table.insert(server.seen, { url = params.url })
+    return 1, 307, { location = params.url, ["set-cookie"] = "c=v" .. ck .. "; Path=/" },
+           "HTTP/1.1 307"
+end)
+ck = 0
+res = Api.makeHttpRequest{ url = A, method = "GET", headers = {} }
+r.check("ever-fresh cookie is still bounded by the hop cap", #server.seen == 6,
+        "made " .. #server.seen)
+
+-- ---------------------------------------------------------------- 308 and the no-Location case
+reset({
+    [A] = { status = 308, headers = { location = "/moved" } },
+    ["https://a.example/moved"] = { status = 200, body = "{}" },
+})
+res = Api.makeHttpRequest{ url = A, method = "POST", body = "x=1", headers = {} }
+r.check("308 followed, method preserved",
+        res.status_code == 200 and server.seen[2] and server.seen[2].method == "POST",
+        "status " .. tostring(res.status_code))
+
+reset({ [A] = { status = 307, headers = {} } })
+res = Api.makeHttpRequest{ url = A, method = "GET", headers = {} }
+r.check("307 with no Location does not loop",
+        #server.seen == 1 and res.status_code == 307,
+        "requests=" .. #server.seen .. " status=" .. tostring(res.status_code))
+
+-- ---------------------------------------------------------------- cookie challenge
+-- A 307 plus Set-Cookie asks the client to prove it keeps cookies. Without echoing it the retry
+-- is byte-identical to the request that was just challenged, so the mirror challenges it again.
+local visits = 0
+reset(nil, function(params)
+    visits = visits + 1
+    table.insert(server.seen, { url = params.url,
+                                cookie = params.headers and params.headers["Cookie"] })
+    if visits == 1 then
+        return 1, 307, { location = A, ["set-cookie"] = "DiamWall=tok123; Path=/; HttpOnly" },
+               "HTTP/1.1 307"
+    end
+    if params.sink then params.sink("{}") end
+    return 1, 200, {}, "HTTP/1.1 200"
+end)
+visits = 0
+res = Api.makeHttpRequest{ url = A, method = "GET",
+                           headers = { ["Cookie"] = "remix_userid=42; remix_userkey=abc" } }
+r.check("cookie challenge: retried and succeeded", res.status_code == 200,
+        "status " .. tostring(res.status_code) .. " error=" .. tostring(res.error))
+r.check("cookie challenge: exactly 2 requests", #server.seen == 2, "made " .. #server.seen)
+local sent = server.seen[2] and server.seen[2].cookie or ""
+r.check("cookie challenge: WAF cookie echoed",
+        string.find(sent, "DiamWall=tok123", 1, true) ~= nil, "Cookie: " .. sent)
+r.check("cookie challenge: session cookies preserved",
+        string.find(sent, "remix_userid=42", 1, true) ~= nil and
+        string.find(sent, "remix_userkey=abc", 1, true) ~= nil, "Cookie: " .. sent)
+r.check("cookie challenge: attributes not sent as cookies",
+        string.find(sent, "Path=", 1, true) == nil and
+        string.find(sent, "HttpOnly", 1, true) == nil, "Cookie: " .. sent)
+
+-- The security property of the whole feature, asserted rather than assumed.
+visits = 0
+reset(nil, function(params)
+    visits = visits + 1
+    table.insert(server.seen, { url = params.url,
+                                cookie = params.headers and params.headers["Cookie"] })
+    if visits == 1 then
+        return 1, 307, { location = "https://evil.example/eapi/user/login",
+                         ["set-cookie"] = "SECRET=leakme; Path=/" }, "HTTP/1.1 307"
+    end
+    if params.sink then params.sink("{}") end
+    return 1, 200, {}, "HTTP/1.1 200"
+end)
+visits = 0
+res = Api.makeHttpRequest{ url = A, method = "GET", headers = {} }
+r.check("cross-host cookie case: the hop actually happened", #server.seen == 2,
+        "made " .. #server.seen)
+r.check("cross-host cookie case: went to the other host",
+        server.seen[2] and server.seen[2].url == "https://evil.example/eapi/user/login",
+        server.seen[2] and server.seen[2].url or "no 2nd request")
+local cross = server.seen[2] and server.seen[2].cookie or ""
+r.check("cookie is NOT replayed to another host",
+        string.find(cross, "SECRET", 1, true) == nil,
+        "leaked to " .. tostring(server.seen[2] and server.seen[2].url) .. ": " .. cross)
+
+-- ---------------------------------------------------------------- onRedirect still owns moves
+-- A cross-host hop must still hand control to the caller's rebuild: only it can reconstruct the
+-- API path from config against the new base. Regression guard for the login and search flows.
+reset({
+    [A] = { status = 307, headers = { location = "https://b.example/" } },
+    ["https://b.example/eapi/rebuilt"] = { status = 200, body = "{}" },
+})
+res = Api.makeHttpRequest{
+    url = A, method = "GET", headers = {},
+    onRedirect = function() return "https://b.example/eapi/rebuilt" end,
+}
+r.check("cross-host: onRedirect string is used",
+        res.status_code == 200 and server.seen[2] and
+        server.seen[2].url == "https://b.example/eapi/rebuilt",
+        server.seen[2] and server.seen[2].url or "no 2nd request")
+r.check("cross-host: base still pinned for the rebuild",
+        pinned == "https://b.example", tostring(pinned))
+
+reset({ [A] = { status = 307, headers = { location = "https://b.example/" } } })
+local called_with = nil
+res = Api.makeHttpRequest{
+    url = A, method = "GET", headers = {},
+    onRedirect = function()
+        return function(rr) called_with = rr; return { status_code = 200, handled = true } end
+    end,
+}
+r.check("cross-host: onRedirect function is invoked",
+        res and res.handled == true and called_with and
+        called_with.real_url_base == "https://b.example",
+        "handled=" .. tostring(res and res.handled))
+
+r.finish()

--- a/test/redirect_resolve_harness.lua
+++ b/test/redirect_resolve_harness.lua
@@ -1,0 +1,84 @@
+-- Which redirects does the plugin follow, and where does it resolve them to?
+--
+-- Two users reported "HTTP Error: 307" on sign-in. 307 was already an accepted status, so the
+-- status code was never the problem -- the Location handling was. Only an absolute cross-host
+-- URL was followed; a relative or same-host target was refused and the raw 30x was handed to the
+-- user as an error. That covered http -> https on the same host, which is about the most ordinary
+-- redirect a server can send.
+--
+-- Checks both that a redirect is followed and that it resolves to the right absolute URL.
+-- real_url_base must stay cross-host-only: it is the mirror-move signal that pins a new base URL,
+-- and setting it for an in-site hop would repoint every later request at the wrong root.
+
+local PLUGIN = assert(arg[1], "usage: luajit redirect_resolve_harness.lua <plugin-root> <luasocket-src>")
+local LUASOCKET = assert(arg[2], "usage: luajit redirect_resolve_harness.lua <plugin-root> <luasocket-src>")
+
+local support = dofile(PLUGIN .. "/test/support.lua")
+local socket_url = support.preload_socket(LUASOCKET)
+local r = support.reporter()
+
+local checkRedirect = support.extract_function(
+    PLUGIN .. "/zlibrary/api.lua", "_checkAndHandleRedirect",
+    {
+        socket_url = socket_url,
+        logger = { err = function() end, dbg = function() end, info = function() end },
+        string = string, type = type, tostring = tostring, pairs = pairs,
+    })
+
+local CURRENT = "https://z-lib.example/eapi/user/login"
+
+-- label, status, Location, expected resolved target (nil = must NOT follow), expect cross-host
+local cases = {
+    { "absolute, different host",   307, "https://other.example/eapi/user/login",
+      "https://other.example/eapi/user/login", true },
+    { "absolute, SAME host",        307, "https://z-lib.example/eapi/user/login/",
+      "https://z-lib.example/eapi/user/login/", false },
+    { "root-relative path",         307, "/eapi/v2/user/login",
+      "https://z-lib.example/eapi/v2/user/login", false },
+    { "relative path",              307, "login2",
+      "https://z-lib.example/eapi/user/login2", false },
+    { "protocol-relative //host",   307, "//other.example/eapi/user/login",
+      "https://other.example/eapi/user/login", true },
+    { "308 permanent, cross host",  308, "https://other.example/eapi/user/login",
+      "https://other.example/eapi/user/login", true },
+    { "302 found, cross host",      302, "https://other.example/eapi/user/login",
+      "https://other.example/eapi/user/login", true },
+    { "303 see other, relative",    303, "/eapi/user/session",
+      "https://z-lib.example/eapi/user/session", false },
+    { "same host, same path",       301, "https://z-lib.example/eapi/user/login",
+      "https://z-lib.example/eapi/user/login", false },
+    { "no Location at all",         307, nil, nil, false },
+    { "non-redirect status",        200, "https://other.example/x", nil, false },
+}
+
+print(string.format("  request URL: %s\n", CURRENT))
+for _, c in ipairs(cases) do
+    local label, status, location, want_target, want_cross = c[1], c[2], c[3], c[4], c[5]
+    local headers = location and { location = location } or {}
+    -- skip_check = false: the path taken whenever LuaSocket is not following redirects itself
+    local res = checkRedirect(false, status, CURRENT, headers)
+
+    if want_target == nil then
+        r.check(string.format("%-30s %s  refuses", label, status),
+                res.real_url == nil, "followed to " .. tostring(res.real_url))
+    else
+        r.check(string.format("%-30s %s  -> %s", label, status, want_target),
+                res.real_url == want_target,
+                res.real_url and ("resolved to " .. res.real_url)
+                             or ("REFUSED: " .. tostring(res.error)))
+        r.check(string.format("%-30s %s  pins base: %s", label, status, tostring(want_cross)),
+                (res.real_url_base ~= nil) == want_cross,
+                "real_url_base = " .. tostring(res.real_url_base))
+    end
+end
+
+-- The two shapes that actually reached users, spelled out so a regression names itself.
+local http_to_https = checkRedirect(false, 307, "http://z-lib.fo/eapi/user/login",
+                                    { location = "https://z-lib.fo/eapi/user/login" })
+r.check("http -> https on the same host is followed",
+        http_to_https.real_url == "https://z-lib.fo/eapi/user/login",
+        tostring(http_to_https.error))
+r.check("http -> https does not pin a new base",
+        http_to_https.real_url_base == nil, tostring(http_to_https.real_url_base))
+
+r.finish()

--- a/test/retry_message_harness.lua
+++ b/test/retry_message_harness.lua
@@ -1,0 +1,130 @@
+-- Does the retry dialog classify a failure correctly, and then say something true about it?
+--
+-- The api layer produced a correct, actionable error for a bot-walled mirror and the dialog threw
+-- it away: the flag was added to the guard that opens the dialog and to the auto-discovery button,
+-- but not to the if/elseif that picks the wording, so it fell to the generic branch and the user
+-- was told "due to a temporary issue" about the one failure here that is permanent.
+--
+-- This drives the real classification too, not just the wording. An earlier version injected
+-- is_blocked as a ready-made boolean and so tested only half the path: deleting the line that
+-- derives it, or dropping it from the guard, left the whole suite green. It now starts from a raw
+-- error string and the real Api.BLOCKED_TEXT / Api.DNS_ERROR_TEXT values, so the classification,
+-- the guard and the wording are all under test.
+
+local PLUGIN = assert(arg[1], "usage: luajit retry_message_harness.lua <plugin-root> <luasocket-src>")
+local LUASOCKET = assert(arg[2], "usage: luajit retry_message_harness.lua <plugin-root> <luasocket-src>")
+
+local support = dofile(PLUGIN .. "/test/support.lua")
+support.preload_socket(LUASOCKET)
+local r = support.reporter()
+
+local UI = PLUGIN .. "/zlibrary/ui.lua"
+
+-- From the first classification line through the end of the wording chain, so the flags, the
+-- guard and the branch selection are all real code rather than harness inputs.
+local block = support.extract_block(UI, "(local is_http_400 =.-\n        end\n)")
+
+-- Two adjustments, neither touching the logic under test. The captured text opens
+-- `if is_http_400 ... then` and closes only the inner wording chain, so the outer guard needs
+-- its `end`. And both results are declared local inside that guard, which puts them out of
+-- reach once it closes -- dropping `local` lets them land in the environment where the harness
+-- can read which branch actually ran.
+block = block
+    :gsub("local offer_discover", "offer_discover", 1)
+    :gsub("local retry_message\n", "retry_message = nil\n", 1)
+    .. "end\n"
+
+-- The constants the classifier matches on, read from api.lua rather than retyped: a reworded
+-- message must not be able to silently stop being recognised.
+local API = PLUGIN .. "/zlibrary/api.lua"
+local function api_constant(name)
+    local fh = assert(io.open(API))
+    local src = fh:read("*a")
+    fh:close()
+    local v = src:match("Api%." .. name .. ' = T%("([^"]+)"%)')
+    assert(v, "could not read Api." .. name .. " from api.lua")
+    return v
+end
+local BLOCKED_TEXT = api_constant("BLOCKED_TEXT")
+local DNS_ERROR_TEXT = api_constant("DNS_ERROR_TEXT")
+
+-- Run the real block against a raw error string, as showRetryErrorDialog would.
+local function classify(error_string)
+    local env = {
+        string = string,
+        T = function(s) return s end,
+        Api = { BLOCKED_TEXT = BLOCKED_TEXT, DNS_ERROR_TEXT = DNS_ERROR_TEXT },
+        error_string = error_string,
+        operation_name = "Sign-in",
+        operation_key = "login",
+        TIMEOUT_GETTERS = { login = function() return { 10, 15 } end },
+    }
+    local chunk = assert(loadstring(block, "=classify"))
+    setfenv(chunk, env)
+    chunk()
+    return { message = env.retry_message, offer_discover = env.offer_discover }
+end
+
+local BLOCKED = BLOCKED_TEXT .. " (1lib.sk). Try a different Z-library server."
+local TIMEOUT = "Request timed out - please check your connection and try again"
+local DNS     = DNS_ERROR_TEXT .. " (z-lib.example). The Z-library address may be wrong."
+local NETWORK = "Network connection error - please check your internet connection and try again"
+local OTHER   = "HTTP Error: 400 (Bad Request)"
+
+local blocked = classify(BLOCKED)
+r.check("blocked mirror: dialog opens at all",
+        blocked.message ~= nil, "no message produced -- the guard did not admit it")
+r.check("blocked mirror: keeps the actionable message",
+        blocked.message and blocked.message:find("refusing automated access", 1, true) ~= nil,
+        "got: " .. tostring(blocked.message))
+r.check("blocked mirror: does NOT claim a temporary issue",
+        blocked.message and blocked.message:find("temporary issue", 1, true) == nil,
+        "got: " .. tostring(blocked.message))
+r.check("blocked mirror: names the host so the user can act",
+        blocked.message and blocked.message:find("1lib.sk", 1, true) ~= nil,
+        "got: " .. tostring(blocked.message))
+-- Retry can never clear a wall, so the button that switches mirrors has to be on screen.
+r.check("blocked mirror: offers auto-discovery",
+        blocked.offer_discover == true, "offer_discover = " .. tostring(blocked.offer_discover))
+
+local timeout = classify(TIMEOUT)
+r.check("timeout: reports a timeout and its budget",
+        timeout.message and timeout.message:find("timeout", 1, true) ~= nil
+            and timeout.message:find("(10s)", 1, true) ~= nil,
+        "got: " .. tostring(timeout.message))
+r.check("timeout: offers auto-discovery", timeout.offer_discover == true,
+        tostring(timeout.offer_discover))
+
+local dns = classify(DNS)
+r.check("dns: reports the address could not be found",
+        dns.message and dns.message:find("address could not be found", 1, true) ~= nil,
+        "got: " .. tostring(dns.message))
+r.check("dns: offers auto-discovery", dns.offer_discover == true, tostring(dns.offer_discover))
+
+local net = classify(NETWORK)
+r.check("network: reports a network error",
+        net.message and net.message:find("network error", 1, true) ~= nil,
+        "got: " .. tostring(net.message))
+-- A network fault is the user's connection, not the mirror, so switching servers is not the fix.
+r.check("network: does NOT offer auto-discovery",
+        net.offer_discover == nil, tostring(net.offer_discover))
+
+local other = classify(OTHER)
+r.check("anything else: falls back to the generic wording",
+        other.message and other.message:find("temporary issue", 1, true) ~= nil,
+        "got: " .. tostring(other.message))
+
+-- An error resembling none of the recognised kinds must not open the dialog at all.
+local unknown = classify("Some entirely unrelated failure")
+r.check("unrecognised error: dialog does not open",
+        unknown.message == nil, "got: " .. tostring(unknown.message))
+
+-- Every kind must read differently; sharing another branch's wording by accident is exactly
+-- what happened to the blocked case.
+local seen = {}
+for _, m in ipairs({ blocked.message, timeout.message, dns.message, net.message, other.message }) do
+    r.check("distinct wording: " .. tostring(m):sub(1, 42), not seen[m], "duplicate wording")
+    seen[m] = true
+end
+
+r.finish()

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,0 +1,171 @@
+#!/bin/sh
+# Run every harness in this directory.
+#
+# These need KOReader's own LuaJIT. The plugin targets Lua 5.1 semantics, and the harnesses
+# themselves use loadstring and setfenv to compile file-local functions out of the source --
+# neither exists in a system Lua 5.4, so running there produces failures that say nothing
+# about the plugin. Point KOREADER_DIR at a built KOReader checkout, or let this find one.
+#
+#   ./test/run.sh                    run everything
+#   ./test/run.sh redirect           run harnesses whose name matches
+#   KOREADER_DIR=/path ./test/run.sh use a specific checkout
+#
+# Exits non-zero if any harness fails, so it is usable as a pre-push check.
+
+set -eu
+
+PLUGIN_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+FILTER=${1:-}
+
+# ---------------------------------------------------------------- locate KOReader
+# Machine-local settings first. scripts/ is gitignored, so it is the place for a path that
+# belongs to one machine and has no business being committed. The file is sourced, so it can
+# set anything, but KOREADER_DIR is the only thing read here.
+if [ -z "${KOREADER_DIR:-}" ] && [ -f "$PLUGIN_DIR/scripts/test-env.sh" ]; then
+    # shellcheck source=/dev/null
+    . "$PLUGIN_DIR/scripts/test-env.sh"
+fi
+
+if [ -z "${KOREADER_DIR:-}" ]; then
+    for candidate in \
+        "${HOME:-}/Documents/Dev/koreader-git" \
+        "${HOME:-}/koreader" \
+        "$PLUGIN_DIR/../koreader-git" \
+        "$PLUGIN_DIR/../koreader" \
+        "$PLUGIN_DIR/../.."
+    do
+        if [ -d "$candidate/base/build" ]; then
+            KOREADER_DIR=$candidate
+            break
+        fi
+    done
+fi
+
+if [ -z "${KOREADER_DIR:-}" ] || [ ! -d "$KOREADER_DIR/base/build" ]; then
+    cat >&2 <<EOF
+Could not find a built KOReader checkout.
+
+These harnesses run against KOReader's LuaJIT and its bundled LuaSocket and fonts, so they
+need one. Clone and build KOReader, then point this at it in any of these ways:
+
+    echo 'KOREADER_DIR=/path/to/koreader' > scripts/test-env.sh   # local, not committed
+    KOREADER_DIR=/path/to/koreader ./test/run.sh                  # one-off
+    ...or place the checkout beside this repository.
+EOF
+    exit 2
+fi
+
+LUAJIT=$(find "$KOREADER_DIR/base/build" -maxdepth 2 -name luajit -type f -perm -u+x 2>/dev/null | head -1)
+LUASOCKET=$(find "$KOREADER_DIR/base/build" -maxdepth 5 -type d -path '*luasocket/source/src' 2>/dev/null | head -1)
+
+if [ -z "$LUAJIT" ]; then
+    echo "No luajit under $KOREADER_DIR/base/build -- is the checkout built?" >&2
+    exit 2
+fi
+# base/build may hold several target triples, including cross-compiled device builds that
+# cannot execute here. Take the first that actually runs.
+if ! "$LUAJIT" -e 'os.exit(0)' >/dev/null 2>&1; then
+    LUAJIT=$(find "$KOREADER_DIR/base/build" -maxdepth 2 -name luajit -type f -perm -u+x 2>/dev/null \
+        | while read -r candidate; do
+              if "$candidate" -e 'os.exit(0)' >/dev/null 2>&1; then echo "$candidate"; break; fi
+          done)
+    if [ -z "$LUAJIT" ]; then
+        echo "No runnable luajit under $KOREADER_DIR/base/build (device build only?)" >&2
+        exit 2
+    fi
+fi
+if [ -z "$LUASOCKET" ]; then
+    echo "No LuaSocket source under $KOREADER_DIR/base/build -- is the checkout built?" >&2
+    exit 2
+fi
+
+echo "  koreader:  $KOREADER_DIR"
+echo "  luajit:    $LUAJIT"
+echo ""
+
+failed=0
+ran=0
+
+# ---------------------------------------------------------------- syntax first
+# A syntax error anywhere makes every behavioural result meaningless, so check it up front.
+#
+# The failures are collected in a file rather than a variable: the loop reading find's output
+# runs in a subshell, so a flag set inside it is discarded when the pipeline ends. An earlier
+# version did exactly that and reported "clean" directly underneath the file it had just
+# printed a FAIL for.
+if [ -z "$FILTER" ]; then
+    printf '== lua syntax ==\n'
+    syntax_log=$(mktemp)
+    find "$PLUGIN_DIR" -name '*.lua' ! -name 'zlibrary_credentials.lua' ! -path '*/test/*' \
+        | sort | while read -r f; do
+            # The path is passed as data. Building Lua source around it meant a directory
+            # containing an apostrophe terminated the string literal and every file in the repo
+            # was reported broken.
+            ZL_FILE="$f" "$LUAJIT" -e 'local p = os.getenv("ZL_FILE") assert(loadfile(p))' \
+                >/dev/null 2>&1 || echo "$f" >> "$syntax_log"
+        done
+    if [ -s "$syntax_log" ]; then
+        while read -r f; do echo "  FAIL $f"; done < "$syntax_log"
+        failed=$((failed + 1))
+        ran=$((ran + 1))
+    else
+        echo "  clean"
+    fi
+    rm -f "$syntax_log"
+    echo ""
+fi
+
+# ---------------------------------------------------------------- harnesses
+
+for harness in "$PLUGIN_DIR"/test/*_harness.lua; do
+    [ -e "$harness" ] || continue
+    name=$(basename "$harness" .lua)
+    case "$name" in
+        *"$FILTER"*) ;;
+        *) continue ;;
+    esac
+    ran=$((ran + 1))
+    printf '== %s ==\n' "$name"
+    if "$LUAJIT" "$harness" "$PLUGIN_DIR" "$LUASOCKET"; then
+        :
+    else
+        failed=$((failed + 1))
+    fi
+    echo ""
+done
+
+have_python3=0
+command -v python3 >/dev/null 2>&1 && have_python3=1
+
+for checker in "$PLUGIN_DIR"/test/*_check.py; do
+    [ -e "$checker" ] || continue
+    if [ "$have_python3" -eq 0 ]; then
+        printf '== %s ==\n  SKIP: python3 not found\n\n' "$(basename "$checker" .py)"
+        continue
+    fi
+    name=$(basename "$checker" .py)
+    case "$name" in
+        *"$FILTER"*) ;;
+        *) continue ;;
+    esac
+    ran=$((ran + 1))
+    printf '== %s ==\n' "$name"
+    if python3 "$checker" "$PLUGIN_DIR" "$KOREADER_DIR"; then
+        :
+    else
+        failed=$((failed + 1))
+    fi
+    echo ""
+done
+
+if [ "$ran" -eq 0 ]; then
+    echo "No harness matched '${FILTER}'." >&2
+    exit 2
+fi
+
+if [ "$failed" -eq 0 ]; then
+    echo "All $ran harnesses passed."
+else
+    echo "$failed of $ran harnesses FAILED." >&2
+fi
+exit $([ "$failed" -eq 0 ] && echo 0 || echo 1)

--- a/test/support.lua
+++ b/test/support.lua
@@ -1,0 +1,184 @@
+-- Shared scaffolding for the harnesses in this directory.
+--
+-- These tests run under KOReader's own LuaJIT against the plugin's real source. They stub the
+-- KOReader modules the plugin requires so a harness can drive api.lua or ui.lua without a device
+-- or a running reader, and they extract functions from source rather than copying them, so a test
+-- cannot quietly drift away from the code it is meant to be checking.
+--
+-- Everything here takes the LuaSocket source directory as a parameter instead of hunting for it,
+-- because test/run.sh already had to locate the KOReader build to find LuaJIT.
+
+local support = {}
+
+-- ---------------------------------------------------------------- reporting
+function support.reporter()
+    local r = { pass = 0, fail = 0 }
+
+    function r.check(label, ok, detail)
+        if ok then
+            r.pass = r.pass + 1
+        else
+            r.fail = r.fail + 1
+        end
+        print(string.format("  [%s] %s%s", ok and "ok  " or "FAIL", label,
+            (not ok and detail and detail ~= "") and ("  <- " .. tostring(detail)) or ""))
+        return ok
+    end
+
+    function r.finish()
+        print(string.format("\n  %d passed, %d failed", r.pass, r.fail))
+        os.exit(r.fail == 0 and 0 or 1)
+    end
+
+    return r
+end
+
+-- ---------------------------------------------------------------- socket
+-- url.lua wants require("socket"), which pulls in the C core we have no reason to build here.
+-- It only uses that module as a namespace to hang socket.url off, so an empty table is enough.
+function support.preload_socket(luasocket_src)
+    assert(type(luasocket_src) == "string" and luasocket_src ~= "",
+        "preload_socket needs the LuaSocket source directory")
+    package.preload["socket"] = function() return {} end
+    package.preload["socket.url"] = function()
+        dofile(luasocket_src .. "/url.lua")
+        return package.loaded["socket"].url
+    end
+    return require("socket.url")
+end
+
+-- ---------------------------------------------------------------- KOReader stubs
+-- Only what the plugin actually reaches for. A harness that needs a module to behave in a
+-- particular way overrides it afterwards; these are the inert defaults.
+function support.preload_koreader_stubs()
+    package.preload["logger"] = function()
+        return { dbg = function() end, info = function() end,
+                 warn = function() end, err = function() end }
+    end
+    package.preload["util"] = function()
+        return {
+            urlEncode = function(s) return s end,
+            trim = function(s) return s end,
+            splitFilePathName = function(p) return p:match("^(.*/)([^/]*)$") end,
+            tableDeepCopy = function(t)
+                local function copy(v, seen)
+                    if type(v) ~= "table" then return v end
+                    if seen[v] then return seen[v] end
+                    local out = {}
+                    seen[v] = out
+                    for k, val in pairs(v) do out[copy(k, seen)] = copy(val, seen) end
+                    return setmetatable(out, getmetatable(v))
+                end
+                return copy(t, {})
+            end,
+        }
+    end
+    -- Raises on ANY body, not merely a malformed one. The plugin wraps every decode in pcall,
+    -- so this exercises those guards; it does mean the JSON-error-extraction path is out of
+    -- scope for these harnesses, which is why nothing here asserts on a decoded API message.
+    package.preload["json"] = function()
+        return { decode = setmetatable({ simple = {} },
+            { __call = function(_, s) return error("not json: " .. tostring(s):sub(1, 40)) end }) }
+    end
+    package.preload["ui/time"] = function()
+        local t = 0
+        return { now = function() t = t + 1 return t end,
+                 since = function() return 1 end,
+                 to_ms = function() return 1 end }
+    end
+    package.preload["socketutil"] = function()
+        return {
+            set_timeout = function() end,
+            reset_timeout = function() end,
+            table_sink = function(tbl)
+                return function(chunk) if chunk then table.insert(tbl, chunk) end return 1 end
+            end,
+        }
+    end
+    -- An ltn12 source is a one-shot generator, and that property is the point of several
+    -- assertions here: a body must be rebuilt per attempt or a retried POST goes out empty.
+    package.preload["ltn12"] = function()
+        return {
+            source = {
+                string = function(s)
+                    local sent = false
+                    return function()
+                        if sent then return nil end
+                        sent = true
+                        return s
+                    end
+                end,
+            },
+        }
+    end
+    package.preload["zlibrary.gettext"] = function()
+        return setmetatable({}, { __call = function(_, s) return s end })
+    end
+end
+
+-- ---------------------------------------------------------------- source extraction
+-- Pull a named local function out of a source file and compile it against a supplied
+-- environment. Testing the real definition rather than a transcription of it is deliberate:
+-- these functions are file-local and cannot be required, and a copied one would keep passing
+-- after the original changed.
+--
+-- The count check is what makes that safe, and it is not incidental. Lua's `.` matches
+-- newlines, so a pattern like this cannot tell live code from text inside a --[[ ]] block, and
+-- string.match returns the FIRST hit. An earlier version had no count check: paste an old copy
+-- of a function into a comment above the working one, break the working one, and the suite
+-- reported 22 passed while exercising the commented-out copy. So refuse to guess -- if a name
+-- appears more than once at the start of a line, fail loudly and make a human look.
+local function read_source(path)
+    local fh = assert(io.open(path), "cannot open " .. path)
+    local src = fh:read("*a")
+    fh:close()
+    -- A leading newline lets the anchored patterns below match a definition on line 1.
+    return "\n" .. src
+end
+
+local function count_matches(src, pattern)
+    local n, pos = 0, 1
+    while true do
+        local s, e = string.find(src, pattern, pos)
+        if not s then break end
+        n = n + 1
+        pos = e + 1
+    end
+    return n
+end
+
+function support.extract_function(path, name, env)
+    local src = read_source(path)
+    -- Anchored to the start of a line so an indented mention, or the name appearing inside
+    -- another expression, is not mistaken for the definition.
+    local anchor = "\nlocal function " .. name .. "%("
+    local found = count_matches(src, anchor)
+    assert(found > 0, string.format("no 'local function %s' in %s", name, path))
+    assert(found == 1, string.format(
+        "'local function %s' appears %d times in %s -- refusing to guess which one is live. "
+        .. "A stale copy left in a comment or a duplicate definition would be tested instead "
+        .. "of the real one, and the suite would pass while the shipped code was broken.",
+        name, found, path))
+
+    local body = src:match("(\nlocal function " .. name .. "%(.-\n)end\n")
+    assert(body, string.format("found 'local function %s' in %s but could not delimit its end",
+        name, path))
+
+    local chunk = assert(loadstring(body .. "end\nreturn " .. name, "=" .. name))
+    setfenv(chunk, env)
+    return chunk()
+end
+
+-- Pull an arbitrary block for logic that lives inline in a large function rather than in one of
+-- its own. Same uniqueness rule, for the same reason.
+function support.extract_block(path, pattern)
+    local src = read_source(path)
+    local found = count_matches(src, pattern)
+    assert(found > 0, "no block matching " .. pattern .. " in " .. path)
+    assert(found == 1, string.format(
+        "the block pattern matches %d times in %s -- refusing to guess which one is live.",
+        found, path))
+    return (src:match(pattern))
+end
+
+return support

--- a/test/timeout_keys_harness.lua
+++ b/test/timeout_keys_harness.lua
@@ -1,0 +1,72 @@
+-- Does every operation_key at a call site actually resolve to a timeout getter?
+--
+-- The retry dialog shows the timeout budget it gave up on -- "(15s)" -- by looking the operation
+-- up in TIMEOUT_GETTERS. A key that does not match simply yields nothing and the hint silently
+-- disappears, which is the exact failure the keys were introduced to fix: the dispatch used to
+-- match English literals against an already-translated name, so outside English nothing ever
+-- matched and no hint was ever shown.
+--
+-- Nothing at runtime complains about a typo'd key, and the behavioural harnesses stub the getters
+-- away, so this compares the two sets directly against the source.
+
+local PLUGIN = assert(arg[1], "usage: luajit timeout_keys_harness.lua <plugin-root> <luasocket-src>")
+
+local support = dofile(PLUGIN .. "/test/support.lua")
+local r = support.reporter()
+
+local function read(path)
+    local fh = assert(io.open(path), "cannot open " .. path)
+    local src = fh:read("*a")
+    fh:close()
+    return src
+end
+
+local ui_src = read(PLUGIN .. "/zlibrary/ui.lua")
+local main_src = read(PLUGIN .. "/main.lua")
+local config_src = read(PLUGIN .. "/zlibrary/config.lua")
+
+-- ---------------------------------------------------------------- the getters that exist
+local table_src = ui_src:match("local TIMEOUT_GETTERS = {(.-)\n}")
+assert(table_src, "could not find TIMEOUT_GETTERS in ui.lua")
+
+local getters, getter_fns = {}, {}
+for key, fn in table_src:gmatch("([%w_]+)%s*=%s*(Config%.[%w_]+)") do
+    getters[key] = fn
+    getter_fns[#getter_fns + 1] = fn
+end
+r.check("TIMEOUT_GETTERS is populated", next(getters) ~= nil, "parsed nothing")
+
+-- ---------------------------------------------------------------- the keys in use
+-- Both spellings: the literal passed as the last argument to showRetryErrorDialog, and the
+-- operation_key field set in a dispatcher options table.
+local used = {}
+for _, src in ipairs({ ui_src, main_src }) do
+    for key in src:gmatch('end,%s*loading_msg,%s*"([%w_]+)"') do used[key] = true end
+    for key in src:gmatch('loading_msg_to_close,%s*"([%w_]+)"') do used[key] = true end
+    for key in src:gmatch('operation_key%s*=%s*"([%w_]+)"') do used[key] = true end
+end
+r.check("found operation keys in use", next(used) ~= nil, "parsed none")
+
+for key in pairs(used) do
+    r.check(string.format("operation_key %q resolves to a getter", key),
+            getters[key] ~= nil,
+            "not in TIMEOUT_GETTERS -- the timeout hint silently vanishes for this operation")
+end
+
+-- ---------------------------------------------------------------- the getters resolve
+for key, fn in pairs(getters) do
+    local name = fn:match("^Config%.([%w_]+)$")
+    r.check(string.format("%s -> %s exists in config.lua", key, fn),
+            config_src:find("function Config." .. name, 1, true) ~= nil,
+            fn .. " is not defined")
+end
+
+-- A getter nothing dispatches to is dead weight, and more usefully, its absence from the call
+-- sites usually means an operation was wired up without its key.
+for key in pairs(getters) do
+    if not used[key] then
+        print(string.format("  note: TIMEOUT_GETTERS has %q but no call site passes it", key))
+    end
+end
+
+r.finish()


### PR DESCRIPTION
These were written one at a time while chasing the redirect and bot-check reports, and lived in a scratch directory that will not survive the session. Each was written against a real bug and each fails against the commit before its fix, so they are worth keeping: the next time a mirror changes behaviour, they are what makes the diagnosis quick rather than exploratory.

test/run.sh finds a built KOReader checkout -- KOREADER_DIR, or a gitignored scripts/test-env.sh, or the usual locations -- and exits non-zero if anything fails, so it works as a pre-push check. The harnesses need KOReader's own LuaJIT: the plugin is Lua 5.1 and the extraction below uses loadstring and setfenv, neither of which a system Lua 5.4 has.

Functions under test are file-local and cannot be required, so the harnesses compile them straight out of the source rather than working from a copy, and refuse to run if a name appears more than once. That guard is not theoretical: without it, pasting a stale copy of a function into a comment above the live one and then breaking the live one left the suite reporting 22 passed while exercising the comment.

An adversarial review of the first draft found several tests that would have passed while the code was broken, all fixed here:
- the retry-dialog harness fed itself a ready-made is_blocked boolean, so deleting the line that derives it, or dropping it from the dialog guard, went unnoticed; it now classifies from a raw error string
- the glyph checker read only the ends of each cmap segment and ignored idDelta/idRangeOffset, so codepoints resolving to .notdef counted as covered
- the runner's syntax check ran its loop in a pipeline, losing the failure flag to the subshell, and printed FAIL and clean on consecutive lines
- a path containing an apostrophe made every file report as broken, because the path was interpolated into Lua source rather than passed as data

Also excludes test/ from the release zip. The markdown collection runs at -maxdepth 2, so test/README.md would have shipped to every user; the .lua finds were already scoped tightly enough that no harness could reach it.

Gaps are recorded in test/README.md rather than left to be discovered: retry_on_stall, the redirect-target cache, a caller-supplied ltn12 source, and anything requiring a live mirror.