### PR TITLE
Stop cache and config requiring each other

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1676,7 +1676,7 @@ function Zlibrary:onExit()
         logger.info("Zlibrary:onExit - Cleaning up " .. self.dialog_manager:getDialogCount() .. " remaining dialogs")
         self.dialog_manager:closeAllDialogs()
     end
-    Cache.autoCacheCleanup()
+    Cache.autoCacheCleanup(Config.getConfigRuntimeCache())
 end
 
 function Zlibrary:onCloseWidget()
@@ -1684,7 +1684,7 @@ function Zlibrary:onCloseWidget()
         logger.info("Zlibrary:onCloseWidget - Cleaning up " .. self.dialog_manager:getDialogCount() .. " remaining dialogs")
         self.dialog_manager:closeAllDialogs()
     end
-    Cache.autoCacheCleanup()
+    Cache.autoCacheCleanup(Config.getConfigRuntimeCache())
 end
 
 return Zlibrary

--- a/test/module_graph_harness.lua
+++ b/test/module_graph_harness.lua
@@ -1,0 +1,108 @@
+-- Do the plugin's own modules form a cycle?
+--
+-- config.lua and cache.lua used to require each other: config needs Cache because it constructs
+-- cache instances, and cache reached back for Config to fetch one value. It worked, because the
+-- reaching-back require sat inside a function and so did not run at load time -- which is
+-- precisely what made it easy to miss. A cycle deferred to call time is still a cycle, and it
+-- constrains every later change to both modules.
+--
+-- Requires are counted wherever they appear, at the top of a file or inside a function, because
+-- a deferred one is exactly the kind this is meant to catch.
+
+local PLUGIN = assert(arg[1], "usage: luajit module_graph_harness.lua <plugin-root> <luasocket-src>")
+
+local support = dofile(PLUGIN .. "/test/support.lua")
+local r = support.reporter()
+
+-- ---------------------------------------------------------------- build the graph
+local MODULES = {
+    "main", "zlibrary.api", "zlibrary.async_helper", "zlibrary.bookdetails_dialog",
+    "zlibrary.cache", "zlibrary.config", "zlibrary.dialog_manager", "zlibrary.gettext",
+    "zlibrary.menu", "zlibrary.multisearch_dialog", "zlibrary.ota", "zlibrary.preloader",
+    "zlibrary.ui",
+}
+
+local function path_of(mod)
+    if mod == "main" then return PLUGIN .. "/main.lua" end
+    return PLUGIN .. "/" .. mod:gsub("%.", "/") .. ".lua"
+end
+
+local deps = {}
+for _, mod in ipairs(MODULES) do
+    local fh = io.open(path_of(mod))
+    if fh then
+        local src = fh:read("*a")
+        fh:close()
+        local seen = {}
+        for dep in src:gmatch('require%("(zlibrary%.[%w_]+)"%)') do
+            if dep ~= mod then seen[dep] = true end
+        end
+        deps[mod] = seen
+    end
+end
+r.check("module graph was read", next(deps) ~= nil, "no sources found under " .. PLUGIN)
+
+-- ---------------------------------------------------------------- find cycles
+-- Depth-first search, reporting the path so a failure names the loop rather than just its
+-- existence.
+local function find_cycle()
+    local state, stack = {}, {}
+    local found
+    local function visit(mod)
+        if found then return end
+        state[mod] = "open"
+        stack[#stack + 1] = mod
+        for dep in pairs(deps[mod] or {}) do
+            if state[dep] == "open" then
+                local from = 1
+                for i, m in ipairs(stack) do if m == dep then from = i break end end
+                local path = {}
+                for i = from, #stack do path[#path + 1] = stack[i] end
+                path[#path + 1] = dep
+                found = table.concat(path, " -> ")
+                return
+            elseif state[dep] ~= "closed" and deps[dep] then
+                visit(dep)
+                if found then return end
+            end
+        end
+        stack[#stack] = nil
+        state[mod] = "closed"
+    end
+    for mod in pairs(deps) do
+        if state[mod] == nil then visit(mod) end
+        if found then break end
+    end
+    return found
+end
+
+local cycle = find_cycle()
+r.check("no module requires itself, directly or through others", cycle == nil, cycle)
+
+-- ---------------------------------------------------------------- the specific pair
+-- Named explicitly so a regression here reads as what it is rather than as a generic cycle.
+r.check("cache stays a leaf: it requires no plugin module",
+        next(deps["zlibrary.cache"] or {}) == nil,
+        "cache now requires: " .. (function()
+            local t = {}
+            for d in pairs(deps["zlibrary.cache"] or {}) do t[#t + 1] = d end
+            return table.concat(t, ", ")
+        end)())
+
+-- gettext is required by nearly everything, so it must depend on nothing of ours.
+r.check("gettext stays a leaf", next(deps["zlibrary.gettext"] or {}) == nil, "gettext gained a dependency")
+
+-- ---------------------------------------------------------------- report the shape
+local names = {}
+for mod in pairs(deps) do names[#names + 1] = mod end
+table.sort(names)
+print("")
+for _, mod in ipairs(names) do
+    local list = {}
+    for d in pairs(deps[mod]) do list[#list + 1] = (d:gsub("^zlibrary%.", "")) end
+    table.sort(list)
+    print(string.format("  %-28s %s", (mod:gsub("^zlibrary%.", "")),
+        #list > 0 and table.concat(list, " ") or "(leaf)"))
+end
+
+r.finish()

--- a/zlibrary/cache.lua
+++ b/zlibrary/cache.lua
@@ -295,15 +295,22 @@ function M:new(o)
     return obj
 end
 
-function M.autoCacheCleanup()
+-- The store that remembers when the last sweep ran is passed in rather than fetched.
+--
+-- Reaching for Config here made the two modules require each other: config needs Cache because
+-- it constructs cache instances, and this was the only thing pulling the other way. The cycle
+-- was real but hidden, deferred to call time by requiring inside the function, which meant it
+-- worked while leaving the modules mutually dependent. Cache is a leaf again now.
+function M.autoCacheCleanup(timestamp_store)
+    if not timestamp_store then
+        logger.warn("Cache.autoCacheCleanup - called with no timestamp store, skipping the sweep")
+        return
+    end
     local CACHE_CLEAN_INTERVAL = 86400
     local current_time = os.time()
-    local Config = require("zlibrary.config")
-    local runtime_cache = Config.getConfigRuntimeCache()
-    local last_cleaned_at = tonumber(runtime_cache:get("last_cleaned_at"))
+    local last_cleaned_at = tonumber(timestamp_store:get("last_cleaned_at"))
     if not last_cleaned_at or (current_time - last_cleaned_at) > CACHE_CLEAN_INTERVAL then
-        runtime_cache:insert("last_cleaned_at", os.time())
-        local logger = require("logger")
+        timestamp_store:insert("last_cleaned_at", os.time())
         logger.info("Cache: Starting global GC clean...")
         local cover_cache = M:new({type="cover"})
         cover_cache:gc_clean()


### PR DESCRIPTION
config.lua requires cache because it constructs cache instances, and cache.lua reached back for Config in exactly one place: autoCacheCleanup, to fetch the store that remembers when the last sweep ran. That is a cycle. It worked only because the reaching-back require sat inside the function rather than at the top of the file, so it resolved at call time -- which is what made it easy to miss and what would have constrained any later change to either module.

The sweep now takes the store as an argument. Both callers are in main.lua, which already holds Config and Cache, so nothing needed rewiring beyond passing it. cache.lua is a leaf again, requiring no plugin module at all, and the redundant logger require inside the function goes with it.

Adds a harness over the whole module graph rather than a guard on this one pair. It walks every zlibrary.* require, at file scope or inside a function -- a deferred require being precisely the kind that hid this one -- and fails with the path of any cycle it finds. It also asserts that cache and gettext stay leaves, since nearly everything depends on gettext and a cycle through it would be unpleasant. Reintroducing the old require makes it fail with "zlibrary.config -> zlibrary.cache -> zlibrary.config".

Checked that the sweep still skips when it ran recently, still runs when overdue, and now warns and returns rather than raising if it is called with no store.