### PR TITLE
Put a search button on the results page

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1374,7 +1374,10 @@ function Zlibrary:displaySearchResults(initial_book_data_list, query_string)
         return true
     end
 
-    self.active_results_menu = Ui.createSearchResultsMenu(self.ui, query_string, menu_items, on_goto_page_handler,  opts)
+    -- Seed the box with the query that produced this page: refining a search is far more common
+    -- than starting an unrelated one, and an empty box throws that away.
+    self.active_results_menu = Ui.createSearchResultsMenu(self.ui, query_string, menu_items, on_goto_page_handler, opts,
+        function() Ui.showSearchDialog(self, query_string) end)
 end
 
 function Zlibrary:downloadBook(book)

--- a/test/results_menu_harness.lua
+++ b/test/results_menu_harness.lua
@@ -1,0 +1,94 @@
+-- Does the search results page offer a way back to the search box?
+--
+-- It did not. You could page through results, open a book, or close the screen -- but to change
+-- the query you had to close it, find the plugin menu and start over. The multi-search screen
+-- has carried a magnifying glass in its title bar all along, so the results page was the odd one
+-- out rather than the design.
+--
+-- Only the icon route exists: KOReader's TitleBar takes callbacks for its left and right icons
+-- and none for the title text, so tapping the "Search Results: x" caption cannot be wired up
+-- however reasonable it sounds.
+--
+-- Drives the real Ui.createSearchResultsMenu with a stub Menu, so what is asserted is what the
+-- widget would actually be constructed with.
+
+local PLUGIN = assert(arg[1], "usage: luajit results_menu_harness.lua <plugin-root> <luasocket-src>")
+
+local support = dofile(PLUGIN .. "/test/support.lua")
+local r = support.reporter()
+
+local block = support.extract_block(PLUGIN .. "/zlibrary/ui.lua",
+    "(\nfunction Ui%.createSearchResultsMenu%(.-\nend\n)")
+
+-- Rebuild the function against a captured Menu, so the constructor arguments are observable.
+local built, shown
+local function make()
+    local Ui = {}
+    local env = {
+        Ui = Ui,
+        string = string,
+        Menu = { new = function(_, spec) built = spec; return spec end },
+        Config = { getSearchOrderName = function() return "Popular" end },
+        T = function(s) return s end,
+        _colon_concat = function(a, b) return a .. ": " .. b end,
+        _showAndTrackDialog = function(m) shown = m end,
+    }
+    local chunk = assert(loadstring(block, "=createSearchResultsMenu"))
+    setfenv(chunk, env)
+    chunk()
+    return Ui.createSearchResultsMenu
+end
+
+local createSearchResultsMenu = make()
+r.check("the function was recovered from ui.lua", type(createSearchResultsMenu) == "function",
+        "got " .. type(createSearchResultsMenu))
+
+-- ---------------------------------------------------------------- with a callback
+local opened_with = nil
+built, shown = nil, nil
+local menu = createSearchResultsMenu({}, "dune", {}, function() end, {},
+    function() opened_with = "called" end)
+
+r.check("results menu shows a search button",
+        built and built.title_bar_left_icon == "appbar.search",
+        "title_bar_left_icon = " .. tostring(built and built.title_bar_left_icon))
+r.check("the button is wired to something",
+        type(menu.onLeftButtonTap) == "function",
+        "onLeftButtonTap = " .. type(menu.onLeftButtonTap))
+
+-- Menu invokes this as a method, so the menu arrives as an argument the handler must tolerate.
+menu:onLeftButtonTap()
+r.check("tapping it reopens the search input", opened_with == "called", "callback never ran")
+
+r.check("the query stays in the title", built and built.title == "Search Results: dune",
+        "title = " .. tostring(built and built.title))
+r.check("the menu is still shown", shown ~= nil, "_showAndTrackDialog was not called")
+
+-- ---------------------------------------------------------------- without one
+-- Every other caller passes nothing, and they must not gain a button that does nothing.
+built = nil
+local plain = createSearchResultsMenu({}, "dune", {}, function() end, {})
+r.check("no callback means no button",
+        built and built.title_bar_left_icon == nil,
+        "title_bar_left_icon = " .. tostring(built and built.title_bar_left_icon))
+r.check("no callback means no handler",
+        plain.onLeftButtonTap == nil,
+        "onLeftButtonTap = " .. type(plain.onLeftButtonTap))
+
+-- ---------------------------------------------------------------- the wiring in main.lua
+-- The harness cannot run main.lua, but it can check the call site still passes a callback: the
+-- feature is two halves and either alone is silent.
+local main_src = (function()
+    local fh = assert(io.open(PLUGIN .. "/main.lua"))
+    local s = fh:read("*a"); fh:close(); return s
+end)()
+local call = main_src:match("Ui%.createSearchResultsMenu%b()")
+    or main_src:match("Ui%.createSearchResultsMenu%(.-\n.-%)")
+r.check("main.lua passes a new-search callback",
+        call ~= nil and call:find("showSearchDialog", 1, true) ~= nil,
+        "call site: " .. tostring(call))
+r.check("the search box is seeded with the current query",
+        call ~= nil and call:find("query_string", 1, true) ~= nil,
+        "call site: " .. tostring(call))
+
+r.finish()

--- a/zlibrary/ui.lua
+++ b/zlibrary/ui.lua
@@ -469,11 +469,17 @@ function Ui.createBookMenuItem(book_data, parent_zlibrary_instance, is_show_cove
     }
 end
 
-function Ui.createSearchResultsMenu(parent_ui_ref, query_string, initial_menu_items, on_goto_page_handler, opts)
+-- on_new_search, when given, puts a magnifying glass in the title bar that reopens the search
+-- input. The results page had no way back to the search box: you closed it, found the menu and
+-- started again. The multi-search screen has had this button all along, so this is parity rather
+-- than a new idea, and it is the only route available -- TitleBar exposes callbacks for its
+-- icons and not for the title text, so tapping the "Search Results: x" caption is not an option.
+function Ui.createSearchResultsMenu(parent_ui_ref, query_string, initial_menu_items, on_goto_page_handler, opts, on_new_search)
     local search_order_name = Config.getSearchOrderName()
     local menu = Menu:new{
         title = _colon_concat(T("Search Results"), query_string),
         subtitle = string.format("%s: %s", T("Sort by"), search_order_name),
+        title_bar_left_icon = on_new_search and "appbar.search" or nil,
         item_table = initial_menu_items,
         parent = parent_ui_ref,
         items_per_page = 10,
@@ -486,6 +492,10 @@ function Ui.createSearchResultsMenu(parent_ui_ref, query_string, initial_menu_it
         list_per_page =opts and opts.search_per_page,
         show_cover = opts and opts.show_cover_search ~= false,
     }
+    if on_new_search then
+        -- Menu calls this as a method, so the menu itself arrives as the first argument.
+        menu.onLeftButtonTap = function() on_new_search() end
+    end
     _showAndTrackDialog(menu)
     return menu
 end


### PR DESCRIPTION
A user asked to be able to start a new search from the results screen. There was no way: you could page through results, open a book, or close it, but to change the query you had to close the screen, find the plugin menu and begin again.

The multi-search screen has carried a magnifying glass in its title bar all along, so this is parity rather than a new idea, and the results page was the odd one out. The button seeds the input with the query already on screen -- refining a search is far more common than starting an unrelated one, and an empty box throws that away.

The same user suggested tapping the "Search Results: x" caption instead or as well. That is not available: KOReader's TitleBar takes callbacks for its left and right icons and none for the title text, so the icon is the whole of what can be offered here.

The button only appears when a caller supplies the callback, so the other users of this menu do not gain one that does nothing. Harness drives the real constructor against a stub Menu and checks both halves, since either alone is silent -- an icon with no handler, or a handler with no icon.

No new strings: the icon is unlabelled and the search dialog it opens is already translated.