### PR TITLE
Sort favourites by save date, most recent first

### DIFF
--- a/test/base_url_harness.lua
+++ b/test/base_url_harness.lua
@@ -164,4 +164,13 @@ r.check("downloaded-books URL defaults to order=date",
         string.find(Config.getDownloadedBooksUrl(), "&order=date", 1, true) ~= nil,
         "got " .. tostring(Config.getDownloadedBooksUrl()))
 
+-- Favourites default to save date (newest first), not the book's own date -- the list is about
+-- what you saved, so it should read most-recently-saved first.
+r.check("favorite-books URL defaults to order=saved_date",
+        string.find(Config.getFavoriteBooksUrl(), "&order=saved_date", 1, true) ~= nil,
+        "got " .. tostring(Config.getFavoriteBooksUrl()))
+r.check("and no longer sorts favourites by the book's own date",
+        string.find(Config.getFavoriteBooksUrl(), "&order=date", 1, true) == nil,
+        "got " .. tostring(Config.getFavoriteBooksUrl()))
+
 r.finish()

--- a/zlibrary/config.lua
+++ b/zlibrary/config.lua
@@ -650,6 +650,10 @@ function Config.getDownloadedBooksUrl(page, order)
     local base = Config.getBaseUrl()
     if not base then return nil end
     
+    -- Note: the downloaded endpoint ignores order (verified against the live API -- every value
+    -- returns the same sequence), unlike saved, which honours saved_date. So this value is inert.
+    -- Sorting downloads by recency would have to be done client-side on each book's date_download,
+    -- and was judged not worth the pagination complexity. Left as-is to avoid re-investigating.
     order = order or {"date"}
     page = page or 1
 
@@ -666,7 +670,12 @@ function Config.getFavoriteBooksUrl(page, order)
     local base = Config.getBaseUrl()
     if not base then return nil end
 
-    order = order or {"date"}
+    -- Default to save date, newest first: a favourites list is most useful showing what you saved
+    -- most recently. order=date sorts by the book's own date, which is unrelated to save order and
+    -- is what made the list look wrongly sorted. The API's "A" suffix marks ascending (titleA,
+    -- filesizeA), so bare "saved_date" is descending = most recent first, as getFavoriteBookIdsUrl
+    -- already uses.
+    order = order or {"saved_date"}
     page = page or 1
     
     local limit = Config.SEARCH_RESULTS_LIMIT


### PR DESCRIPTION
The favourites list requested order=date, which sorts by each book's own publication date, not when it was saved -- so recently favourited books did not appear at the top. It now uses order=saved_date (descending, newest first), matching the value getFavoriteBookIdsUrl already uses and confirmed on device.

Downloaded is deliberately not changed the same way: its endpoint ignores order entirely (verified against the live API -- every value returns the same sequence), so recency there could only be done client-side on date_download, which was judged not worth the pagination complexity. A note records this so it is not re-investigated.