### PR TITLE
feat: refresh the FileManager after a download so the book appears

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ is summarised rather than listed; the commit history has the detail.
 The version number is set by the release workflow, which bumps the patch version on every push
 to `main` — so the top section is the one about to ship.
 
+## 1.0.46
+
+### Fixed
+
+**A finished download shows up in the file browser straight away.** If you stayed in the folder a
+book was downloading into, the new file did not appear until you left the folder and came back —
+which looked like the download had failed. The file list now refreshes itself once the download
+finishes (whether you tap *Close* or have the open-book prompt switched off), so the book is there
+immediately.
+
 ## 1.0.45
 
 ### Added

--- a/test/filemanager_refresh_harness.lua
+++ b/test/filemanager_refresh_harness.lua
@@ -1,0 +1,71 @@
+-- After a download, does the FileManager get refreshed so the new book shows without a manual
+-- reload -- and only when there is a FileManager to refresh?
+--
+-- The reported problem: a reader sitting in the folder a book downloads into does not see it appear,
+-- and reads that as a failed download. The fix refreshes the current folder. Two things have to hold:
+--
+--   * when the FileManager is open (its instance is set), its listing is refreshed exactly once
+--   * when it is not (a book is open, so the instance is nil), nothing happens and nothing crashes --
+--     indexing a nil instance would throw
+--
+-- Drives the real _refreshFileManagerListing extracted from download.lua, with the FileManager module
+-- and UIManager:nextTick stubbed so the deferred refresh runs synchronously and is observable.
+
+local PLUGIN = assert(arg[1], "usage: luajit filemanager_refresh_harness.lua <plugin-root> <luasocket-src>")
+
+local support = dofile(PLUGIN .. "/test/support.lua")
+local r = support.reporter()
+
+local DOWNLOAD = PLUGIN .. "/zlibrary/download.lua"
+
+-- Build the function against a fake FileManager module (returned by the stubbed require) and a
+-- UIManager whose nextTick fires immediately, so the refresh is synchronous and countable.
+local function build(instance)
+    local rec = { refreshes = 0, ticks = 0 }
+    local fm = { instance = instance }
+    if instance then
+        instance.onRefresh = function() rec.refreshes = rec.refreshes + 1 end
+    end
+    local env = {
+        UIManager = { nextTick = function(_, fn) rec.ticks = rec.ticks + 1; fn() end },
+        require = function(name) rec.required = name; return fm end,
+    }
+    rec.fn = support.extract_function(DOWNLOAD, "_refreshFileManagerListing", env)
+    return rec
+end
+
+-- ---------------------------------------------------------------- FileManager open
+do
+    local rec = build({})
+    rec.fn()
+    r.check("the refresh is deferred to the next tick", rec.ticks == 1,
+            "nextTick called " .. rec.ticks .. " times")
+    r.check("it asks for the FileManager module", rec.required == "apps/filemanager/filemanager",
+            "required " .. tostring(rec.required))
+    r.check("the current folder is refreshed exactly once", rec.refreshes == 1,
+            "onRefresh called " .. rec.refreshes .. " times")
+end
+
+-- ---------------------------------------------------------------- FileManager not open (reading)
+do
+    local rec = build(nil)
+    local ok, err = pcall(rec.fn)
+    r.check("it does not crash when no FileManager is open", ok,
+            "raised: " .. tostring(err))
+    r.check("and it refreshes nothing", rec.refreshes == 0,
+            "onRefresh ran " .. rec.refreshes .. " times")
+end
+
+-- ---------------------------------------------------------------- wiring
+local function slurp(path)
+    local fh = assert(io.open(path)); local s = fh:read("*a"); fh:close(); return s
+end
+local src = slurp(DOWNLOAD)
+r.check("the download flow calls the refresh after a finished download",
+        src:find("_refreshFileManagerListing()", 1, true) ~= nil,
+        "download.lua never invokes the refresh")
+r.check("the refresh is guarded on FileManager.instance",
+        src:find("FileManager.instance", 1, true) ~= nil,
+        "the instance guard is missing -- a nil instance would crash")
+
+r.finish()

--- a/zlibrary/download.lua
+++ b/zlibrary/download.lua
@@ -118,6 +118,22 @@ local function _safeMove(from, to)
     return false
 end
 
+-- After a download the FileManager, if the reader is sitting in it, does not notice the new (or
+-- moved) file on its own -- so a book saved into the folder on screen only appears after a manual
+-- refresh, which reads as a failed download. Refresh the current folder for them. Deferred to the
+-- next tick so it runs once the download dialog has closed and the FileManager is the view on
+-- screen; guarded because FileManager.instance is nil whenever a book is open, in which case there
+-- is nothing to refresh and KOReader re-reads the folder on its own when the reader is closed. The
+-- require is lazy: FileManager pulls in much of the app and is only needed at this instant.
+local function _refreshFileManagerListing()
+    UIManager:nextTick(function()
+        local FileManager = require("apps/filemanager/filemanager")
+        if FileManager.instance then
+            FileManager.instance:onRefresh()
+        end
+    end)
+end
+
 function Download.fetchDetailsThenDownload(self, book_stub)
     local function attempt()
         local user_session = Config.getUserSession()
@@ -340,6 +356,12 @@ function Download.run(self, book)
                         logger.info("Zlibrary:downloadBook - Cleaning up dialogs cause wifi is turned off")
                         self.dialog_manager:closeAllDialogs()
                     end
+                    -- The reader stays where it was (typically the FileManager); show the new book
+                    -- without making them leave and re-enter the folder. This runs on both "Close"
+                    -- and the skip-the-prompt path (which calls this with no filing choice). The
+                    -- open path does not need it: opening the book replaces the FileManager, and
+                    -- KOReader re-reads the folder when the reader is closed.
+                    _refreshFileManagerListing()
                 end,
                 Config.getCategories()
             )


### PR DESCRIPTION
When the reader stays in the folder a book downloads into, KOReader's FileManager does not notice the new (or category-moved) file on its own, so the download looks like it failed until the folder is left and re-entered.

Refresh the current folder once the download finishes, on the "Close" and skip-the-prompt paths (the open path replaces the FileManager and KOReader re-reads on reader close). Deferred to the next tick so it runs after the dialog closes, guarded on FileManager.instance so it is a no-op while a book is open. Reported by a user whose relative hit exactly this.