### PR TITLE
fix: clear stale cover widgets to prevent a freed-widget crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ is summarised rather than listed; the commit history has the detail.
 The version number is set by the release workflow, which bumps the patch version on every push
 to `main` — so the top section is the one about to ship.
 
+## 1.0.47
+
+### Fixed
+
+**Browsing book lists with covers no longer crashes on fast page turns.** In cover (grid) view,
+turning the page while covers were still loading could crash KOReader with an *"attempt to index
+field '_bb'"* error. Each cover slot is now cleared properly between refreshes, so a cover image that
+was already freed can no longer be painted again.
+
 ## 1.0.46
 
 ### Fixed

--- a/zlibrary/menu.lua
+++ b/zlibrary/menu.lua
@@ -92,7 +92,24 @@ end
 
 function M:_updateCoverItems(select_number, no_recalculate_dimen)
     if not self.show_cover then return end
-    if not self.item_table or self.items_max_lines then return end
+    if not self.item_table then return end
+
+    -- Every Menu:updateItems frees the widgets embedded in the item rows
+    -- (VerticalGroup:clear -> free, recursively), and MenuItem embeds
+    -- item.state directly. Since item.state lives on the item_table, which
+    -- outlives the rows, anything left there afterwards is a *freed* widget --
+    -- and painting one crashes with "attempt to index field '_bb' (a nil
+    -- value)". Rebuilding only the current page therefore is not enough: any
+    -- item skipped, on another page, or missed because of an early return
+    -- below keeps a dangling widget that KOReader will happily re-embed.
+    --
+    -- So drop every reference first, then rebuild just what this page needs.
+    -- A nil state is safe: MenuItem falls back to a HorizontalSpan.
+    for _, item in ipairs(self.item_table) do
+        item.state = nil
+    end
+
+    if self.items_max_lines then return end
     local perpage = self.perpage
     local current_page = self.page
     local idx_offset = (current_page - 1) * perpage


### PR DESCRIPTION
In cover (grid) view, item.state holds the cover ImageWidget or a placeholder TextBoxWidget, which MenuItem embeds into the row and paints. Menu:updateItems frees the old row widgets, but item.state lives on item_table, which outlives the rows -- so after a refresh it points at an already-freed widget whose _bb is nil. Painting it on the next page turn crashes with "attempt to index field '_bb' (a nil value)" in textboxwidget:paintTo, which fast page turns during cover loading reliably triggered.

_updateCoverItems now drops every item.state before rebuilding the current page's covers, so no dangling freed widget survives to be re-embedded. A nil state is safe: MenuItem falls back to a HorizontalSpan.