### PR TITLE
fix: force a repaint after the post-download FileManager refresh

### DIFF
--- a/test/filemanager_refresh_harness.lua
+++ b/test/filemanager_refresh_harness.lua
@@ -27,7 +27,10 @@ local function build(instance)
         instance.onRefresh = function() rec.refreshes = rec.refreshes + 1 end
     end
     local env = {
-        UIManager = { nextTick = function(_, fn) rec.ticks = rec.ticks + 1; fn() end },
+        UIManager = {
+            nextTick = function(_, fn) rec.ticks = rec.ticks + 1; fn() end,
+            setDirty = function() rec.dirtied = (rec.dirtied or 0) + 1 end,
+        },
         require = function(name) rec.required = name; return fm end,
     }
     rec.fn = support.extract_function(DOWNLOAD, "_refreshFileManagerListing", env)
@@ -44,6 +47,8 @@ do
             "required " .. tostring(rec.required))
     r.check("the current folder is refreshed exactly once", rec.refreshes == 1,
             "onRefresh called " .. rec.refreshes .. " times")
+    r.check("the FileManager is marked dirty so the new file actually repaints",
+            rec.dirtied == 1, "setDirty called " .. tostring(rec.dirtied) .. " times")
 end
 
 -- ---------------------------------------------------------------- FileManager not open (reading)
@@ -54,6 +59,8 @@ do
             "raised: " .. tostring(err))
     r.check("and it refreshes nothing", rec.refreshes == 0,
             "onRefresh ran " .. rec.refreshes .. " times")
+    r.check("and it marks nothing dirty", (rec.dirtied or 0) == 0,
+            "setDirty ran " .. tostring(rec.dirtied) .. " times")
 end
 
 -- ---------------------------------------------------------------- wiring

--- a/zlibrary/download.lua
+++ b/zlibrary/download.lua
@@ -130,6 +130,7 @@ local function _refreshFileManagerListing()
         local FileManager = require("apps/filemanager/filemanager")
         if FileManager.instance then
             FileManager.instance:onRefresh()
+            UIManager:setDirty(FileManager.instance, "ui")
         end
     end)
 end


### PR DESCRIPTION
FileManager.instance:onRefresh() re-reads the folder, but on some devices it did not trigger a repaint on its own, so a freshly downloaded book still looked absent until the next interaction. Mark the FileManager dirty after refreshing so the new file shows immediately.

The refresh harness now asserts the repaint (setDirty called once when the FileManager is open, and not at all when a book is open instead).