### PR TITLE
1.0.47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ answers any request with such a page it is now remembered and skipped by discove
 sweep moves on to a working mirror. The block lasts a good while but is not permanent, so a mirror
 that later drops its anti-bot wall is eventually tried again.
 
+**Auto-discovery no longer settles on the same server every time.** *Auto-discover base URL* used to
+pick the single fastest mirror, so repeated runs kept landing on the same one; it now chooses at
+random among the fastest few, spreading the load. (The server you are currently on is already left
+out of the running, so discovery never just re-picks it.)
+
 ## 1.0.46
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ is summarised rather than listed; the commit history has the detail.
 The version number is set by the release workflow, which bumps the patch version on every push
 to `main` — so the top section is the one about to ship.
 
+## 1.0.47
+
+### Fixed
+
+**Browsing book lists with covers no longer crashes on fast page turns.** In cover (grid) view,
+turning the page while covers were still loading could crash KOReader with an *"attempt to index
+field '_bb'"* error. Each cover slot is now cleared properly between refreshes, so a cover image that
+was already freed can no longer be painted again.
+
 ## 1.0.46
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ turning the page while covers were still loading could crash KOReader with an *"
 field '_bb'"* error. Each cover slot is now cleared properly between refreshes, so a cover image that
 was already freed can no longer be painted again.
 
+**Auto-discovery stops re-picking a server that can't actually search.** Some mirrors answer the
+health check but block the real search behind an anti-bot page (*"This Z-library server is refusing
+automated access"*) — and auto-discovery kept choosing the same one every sweep. When a server
+answers any request with such a page it is now remembered and skipped by discovery, so the next
+sweep moves on to a working mirror. The block lasts a good while but is not permanent, so a mirror
+that later drops its anti-bot wall is eventually tried again.
+
 ## 1.0.46
 
 ### Fixed

--- a/test/blocked_mirrors_harness.lua
+++ b/test/blocked_mirrors_harness.lua
@@ -1,0 +1,129 @@
+-- A mirror can pass discovery's /eapi/info/ok health check and still answer a real /eapi/book/search
+-- with a bot-check page (observed on tw.101d.by). Before this fix, discovery kept re-selecting such a
+-- mirror on every sweep. Now a mirror that answers any request with a challenge is remembered, and
+-- discovery skips it until the block ages out.
+--
+-- The seams under test:
+--   * markMirrorBlocked / isMirrorBlocked round-trip, keyed by scheme://host[:port] so the path of
+--     the challenged request is irrelevant, with a TTL so the block is not permanent
+--   * getSeedUrls drops blocked mirrors -- which is also what stops the same bad mirror winning every
+--     sweep -- but never returns an empty list purely because everything is currently blocked
+--
+-- Uses the real zlibrary.config (like base_url_harness): the behaviour is the interaction of these
+-- functions with the settings object and the real URL parsing, which a transcription could not test.
+
+local PLUGIN = assert(arg[1], "usage: luajit blocked_mirrors_harness.lua <plugin-root> <luasocket-src>")
+local LUASOCKET = assert(arg[2], "usage: luajit blocked_mirrors_harness.lua <plugin-root> <luasocket-src>")
+
+package.path = PLUGIN .. "/?.lua;" .. package.path
+local support = dofile(PLUGIN .. "/test/support.lua")
+support.preload_socket(LUASOCKET)
+support.preload_koreader_stubs()
+local r = support.reporter()
+
+package.preload["util"] = function()
+    return {
+        trim = function(s) return s:match("^%s*(.-)%s*$") end,
+        urlEncode = function(s) return s end,
+    }
+end
+
+local function make_settings(data)
+    local s = { data = data or {} }
+    function s:readSetting(key, default)
+        local v = self.data[key]
+        if v == nil then return default end
+        return v
+    end
+    function s:saveSetting(key, value) self.data[key] = value return self end
+    function s:delSetting(key) self.data[key] = nil return self end
+    function s:flush() return self end
+    return s
+end
+
+local plugin_settings = make_settings()
+package.preload["datastorage"] = function()
+    return { getSettingsDir = function() return "/nonexistent-test-dir" end }
+end
+package.preload["luasettings"] = function()
+    return { open = function(_, path)
+        if string.find(path, "zlibrary%.lua$") then return plugin_settings end
+        return make_settings()
+    end }
+end
+package.preload["zlibrary.cache"] = function()
+    return { new = function()
+        local store = {}
+        return {
+            get = function(_, k) return store[k] end,
+            insert = function(_, k, v) store[k] = v return true end,
+            remove = function(_, k) store[k] = nil return true end,
+            clear = function() store = {} return true end,
+        }
+    end }
+end
+
+G_reader_settings = make_settings({ home_dir = "/home" })
+
+local Config = require("zlibrary.config")
+
+local function contains(list, url)
+    for _, s in ipairs(list) do if s.url == url then return true end end
+    return false
+end
+
+-- ---------------------------------------------------------------- mark / isBlocked / key / TTL
+local NOW = 1000000
+Config.markMirrorBlocked("https://tw.101d.by/eapi/book/search", NOW)
+
+r.check("a challenged mirror is remembered as blocked",
+        Config.isMirrorBlocked("https://tw.101d.by", NOW) == true,
+        "not blocked")
+r.check("the block is keyed by host, not the challenged path",
+        Config.isMirrorBlocked("https://tw.101d.by/eapi/info/ok", NOW) == true,
+        "a different path on the same host was not recognised")
+r.check("a trailing slash does not change the key",
+        Config.isMirrorBlocked("https://tw.101d.by/", NOW) == true,
+        "trailing slash broke the match")
+r.check("an unrelated mirror is not blocked",
+        Config.isMirrorBlocked("https://z-lib.fo", NOW) == false,
+        "wrongly reported blocked")
+
+r.check("the block still holds just before the TTL",
+        Config.isMirrorBlocked("https://tw.101d.by", NOW + Config.BLOCKED_MIRROR_TTL - 1) == true,
+        "expired too early")
+r.check("the block expires once the TTL passes",
+        Config.isMirrorBlocked("https://tw.101d.by", NOW + Config.BLOCKED_MIRROR_TTL + 1) == false,
+        "still blocked after the TTL -- a recovered mirror would be shunned forever")
+
+-- ---------------------------------------------------------------- getSeedUrls drops blocked mirrors
+-- getSeedUrls checks against real os.time(), so mark without an injected timestamp (a fresh block).
+local seeds_before = Config.getSeedUrls()
+r.check("discovery offers seeds to begin with", #seeds_before > 0, "no seeds")
+
+local victim = seeds_before[1].url
+Config.markMirrorBlocked(victim)
+local seeds_after = Config.getSeedUrls()
+r.check("a bot-blocked mirror is dropped from the seed list",
+        not contains(seeds_after, victim), victim .. " is still offered")
+r.check("exactly the blocked mirror is dropped, nothing else",
+        #seeds_after == #seeds_before - 1,
+        string.format("before=%d after=%d", #seeds_before, #seeds_after))
+
+-- ---------------------------------------------------------------- never strand discovery
+-- Blocking every known seed must not leave discovery with nothing to try: the block is transient,
+-- so a last-resort list of the blocked ones is better than an empty sweep.
+for _, u in ipairs(Config.SEED_URLS) do Config.markMirrorBlocked(u) end
+local fallback = Config.getSeedUrls()
+r.check("when every seed is blocked, discovery still gets a non-empty fallback list",
+        #fallback > 0, "discovery was left with no seeds at all")
+
+-- ---------------------------------------------------------------- wiring
+local api_src = (function()
+    local fh = assert(io.open(PLUGIN .. "/zlibrary/api.lua")); local s = fh:read("*a"); fh:close(); return s
+end)()
+r.check("makeHttpRequest records a mirror that answers a bot-check page",
+        select(2, api_src:gsub("Config%.markMirrorBlocked%(options%.url%)", "")) == 2,
+        "expected both challenge branches (status!=200 and 200-with-interstitial) to record the block")
+
+r.finish()

--- a/test/bot_challenge_harness.lua
+++ b/test/bot_challenge_harness.lua
@@ -19,11 +19,15 @@ support.preload_socket(LUASOCKET)
 support.preload_koreader_stubs()
 local r = support.reporter()
 
+-- Recorded so the tests can assert a challenge marks the mirror blocked (and nothing else does).
+-- Reassigned per case; the stub reads the variable, so a fresh table takes effect.
+local blocked_calls = {}
 package.preload["zlibrary.config"] = function()
     return {
         setCacheRealUrl = function() end,
         getCacheRealUrl = function() return nil end,
         clearCacheRealUrlIfPinned = function() return false end,
+        markMirrorBlocked = function(url) table.insert(blocked_calls, url) end,
     }
 end
 
@@ -57,6 +61,7 @@ serve = function(p)
     if p.sink then p.sink(DIAMWALL_BODY) end
     return 1, 513, {}, "HTTP/1.1 513 "
 end
+blocked_calls = {}
 local res = Api.makeHttpRequest{ url = "https://1lib.sk/eapi/user/login", method = "GET", headers = {} }
 r.check("challenge recognised, not reported as a bare status",
         res.error and res.error:find("refusing automated access", 1, true) ~= nil,
@@ -66,6 +71,9 @@ r.check("error names the host so the user can act",
 r.check("error says what to do about it",
         res.error and res.error:find("different Z%-library server") ~= nil, tostring(res.error))
 r.check("bounded: 2 requests, no hammering", n == 2, "made " .. n)
+r.check("the challenged mirror is recorded as blocked so discovery skips it",
+        #blocked_calls == 1 and blocked_calls[1] == "https://1lib.sk/eapi/user/login",
+        "blocked: " .. table.concat(blocked_calls, ", "))
 
 -- ---------------------------------------------------------------- must not misfire
 n = 0
@@ -74,12 +82,16 @@ serve = function(p)
     if p.sink then p.sink('{"success":0,"error":"Incorrect email or password"}') end
     return 1, 401, {}, "HTTP/1.1 401"
 end
+blocked_calls = {}
 res = Api.makeHttpRequest{ url = "https://good.example/eapi/user/login", method = "GET", headers = {} }
 r.check("a JSON API error is not misread as a challenge",
         res.error and res.error:find("refusing automated access", 1, true) == nil,
         tostring(res.error))
+r.check("a JSON API error does not block the mirror", #blocked_calls == 0,
+        "wrongly blocked: " .. table.concat(blocked_calls, ", "))
 
 n = 0
+blocked_calls = {}
 serve = function(p)
     n = n + 1
     if p.sink then p.sink("<html><head><title>502 Bad Gateway</title></head><body>nginx</body></html>") end
@@ -89,6 +101,8 @@ res = Api.makeHttpRequest{ url = "https://good.example/eapi/user/login", method 
 r.check("an ordinary HTML error page is not misread as a challenge",
         res.error and res.error:find("refusing automated access", 1, true) == nil,
         tostring(res.error))
+r.check("an ordinary HTML error page does not block the mirror", #blocked_calls == 0,
+        "wrongly blocked: " .. table.concat(blocked_calls, ", "))
 
 -- ---------------------------------------------------------------- 200 with a challenge body
 -- A WAF can serve the interstitial with a 200 instead of an error status. This used to fall
@@ -100,15 +114,20 @@ serve = function(p)
     if p.sink then p.sink(DIAMWALL_BODY) end
     return 1, 200, {}, "HTTP/1.1 200"
 end
+blocked_calls = {}
 res = Api.makeHttpRequest{ url = "https://waf.example/eapi/user/login", method = "GET", headers = {} }
 r.check("a challenge served with status 200 is still recognised",
         res.error and res.error:find("refusing automated access", 1, true) ~= nil,
         "error=" .. tostring(res.error))
 r.check("the 200 challenge error also names the host",
         res.error and res.error:find("waf.example", 1, true) ~= nil, tostring(res.error))
+r.check("the 200 challenge also blocks the mirror",
+        #blocked_calls == 1 and blocked_calls[1] == "https://waf.example/eapi/user/login",
+        "blocked: " .. table.concat(blocked_calls, ", "))
 
 -- A book whose description happens to quote a challenge phrase must not poison a good response.
 n = 0
+blocked_calls = {}
 serve = function(p)
     n = n + 1
     if p.sink then p.sink('{"success":1,"book":{"title":"Verifying your browser: a history"}}') end
@@ -118,5 +137,7 @@ res = Api.makeHttpRequest{ url = "https://good.example/eapi/book/1", method = "G
 r.check("a JSON response quoting a challenge phrase is not misread as a challenge",
         res.status_code == 200 and res.error == nil,
         "status=" .. tostring(res.status_code) .. " error=" .. tostring(res.error))
+r.check("a JSON response quoting a challenge phrase does not block the mirror",
+        #blocked_calls == 0, "wrongly blocked: " .. table.concat(blocked_calls, ", "))
 
 r.finish()

--- a/test/discovery_selection_harness.lua
+++ b/test/discovery_selection_harness.lua
@@ -1,0 +1,78 @@
+-- Which mirror does discovery settle on? Picking the single fastest every time lands the reader on
+-- the same server on every sweep (the subtle half of the tw.101d.by report). _pickFastestRandom
+-- spreads the choice over the fastest few instead, so it must:
+--   * choose only from the k fastest, never a slow one
+--   * still be able to pick any of those k (not collapse back to the single quickest)
+--   * treat a mirror that reported no timing as slowest, and never mutate the caller's list
+--
+-- Drives the real _pickFastestRandom extracted from discovery.lua, with math.random stubbed so the
+-- choice is observable.
+
+local PLUGIN = assert(arg[1], "usage: luajit discovery_selection_harness.lua <plugin-root> <luasocket-src>")
+
+local support = dofile(PLUGIN .. "/test/support.lua")
+local r = support.reporter()
+
+-- math.random is stubbed per case to return a chosen index into the top-k; math.huge is real.
+local forced_index = 1
+local function build()
+    return support.extract_function(PLUGIN .. "/zlibrary/discovery.lua", "_pickFastestRandom", {
+        type = type,
+        ipairs = ipairs,
+        table = table,
+        math = { huge = math.huge, min = math.min, random = function(n) return math.min(forced_index, n) end },
+    })
+end
+local pick = build()
+
+local function cands(...)
+    local t = {}
+    for _, e in ipairs({...}) do t[#t + 1] = { url = e[1], elapsed = e[2] } end
+    return t
+end
+
+-- ---------------------------------------------------------------- empty / degenerate
+r.check("no candidates -> nil", pick({}, 5) == nil, "expected nil")
+forced_index = 1
+r.check("a single candidate is returned", pick(cands({ "a", 10 }), 5) == "a", "expected a")
+
+-- ---------------------------------------------------------------- picks within the fastest k
+-- Unsorted input; the three fastest are b(5), d(8), a(10) in that order; e(20),c(30) must be unreachable.
+local list = cands({ "a", 10 }, { "c", 30 }, { "b", 5 }, { "e", 20 }, { "d", 8 })
+forced_index = 1
+r.check("index 1 -> the fastest", pick(list, 3) == "b", "got " .. tostring(pick(list, 3)))
+forced_index = 2
+r.check("index 2 -> the second fastest", pick(list, 3) == "d", "got " .. tostring(pick(list, 3)))
+forced_index = 3
+r.check("index 3 -> the third fastest", pick(list, 3) == "a", "got " .. tostring(pick(list, 3)))
+
+-- The slow ones are never in the running: even asking for index 5, random() is clamped to k=3.
+forced_index = 5
+r.check("a slower mirror outside the top-k is never chosen",
+        pick(list, 3) == "a", "a slow mirror leaked in: " .. tostring(pick(list, 3)))
+
+-- ---------------------------------------------------------------- k larger than the list
+forced_index = 4
+r.check("k beyond the list size is clamped to the list",
+        pick(cands({ "a", 10 }, { "b", 5 }), 5) == "a",
+        "expected the slower of the two at index 2 (clamped)")
+
+-- ---------------------------------------------------------------- missing timings sort last
+forced_index = 1
+local with_nil = cands({ "slow", 100 })
+with_nil[#with_nil + 1] = { url = "untimed" } -- no elapsed
+with_nil[#with_nil + 1] = { url = "fast", elapsed = 5 }
+r.check("a mirror with a real timing beats one with none",
+        pick(with_nil, 1) == "fast", "got " .. tostring(pick(with_nil, 1)))
+forced_index = 3
+r.check("a mirror with no timing sorts last",
+        pick(with_nil, 3) == "untimed", "got " .. tostring(pick(with_nil, 3)))
+
+-- ---------------------------------------------------------------- does not mutate the caller's list
+forced_index = 1
+local original = cands({ "a", 10 }, { "b", 5 })
+pick(original, 5)
+r.check("the caller's list is left in its original order",
+        original[1].url == "a" and original[2].url == "b", "the input list was reordered")
+
+r.finish()

--- a/test/filemanager_refresh_harness.lua
+++ b/test/filemanager_refresh_harness.lua
@@ -27,7 +27,10 @@ local function build(instance)
         instance.onRefresh = function() rec.refreshes = rec.refreshes + 1 end
     end
     local env = {
-        UIManager = { nextTick = function(_, fn) rec.ticks = rec.ticks + 1; fn() end },
+        UIManager = {
+            nextTick = function(_, fn) rec.ticks = rec.ticks + 1; fn() end,
+            setDirty = function() rec.dirtied = (rec.dirtied or 0) + 1 end,
+        },
         require = function(name) rec.required = name; return fm end,
     }
     rec.fn = support.extract_function(DOWNLOAD, "_refreshFileManagerListing", env)
@@ -44,6 +47,8 @@ do
             "required " .. tostring(rec.required))
     r.check("the current folder is refreshed exactly once", rec.refreshes == 1,
             "onRefresh called " .. rec.refreshes .. " times")
+    r.check("the FileManager is marked dirty so the new file actually repaints",
+            rec.dirtied == 1, "setDirty called " .. tostring(rec.dirtied) .. " times")
 end
 
 -- ---------------------------------------------------------------- FileManager not open (reading)
@@ -54,6 +59,8 @@ do
             "raised: " .. tostring(err))
     r.check("and it refreshes nothing", rec.refreshes == 0,
             "onRefresh ran " .. rec.refreshes .. " times")
+    r.check("and it marks nothing dirty", (rec.dirtied or 0) == 0,
+            "setDirty ran " .. tostring(rec.dirtied) .. " times")
 end
 
 -- ---------------------------------------------------------------- wiring

--- a/zlibrary/api.lua
+++ b/zlibrary/api.lua
@@ -649,6 +649,8 @@ function Api.makeHttpRequest(options)
                     Api.BLOCKED_TEXT,
                     (parsed and parsed.host) or tostring(options.url),
                     T("Try a different Z-library server."))
+                -- Remember this mirror so discovery skips it and stops re-selecting it every sweep.
+                Config.markMirrorBlocked(options.url)
                 logger.err(string.format(
                     "Zlibrary:Api.makeHttpRequest - %s answered a bot-check page (status %s), not the API",
                     tostring(options.url), tostring(result.status_code)))
@@ -667,6 +669,8 @@ function Api.makeHttpRequest(options)
             Api.BLOCKED_TEXT,
             (parsed and parsed.host) or tostring(options.url),
             T("Try a different Z-library server."))
+        -- Remember this mirror so discovery skips it and stops re-selecting it every sweep.
+        Config.markMirrorBlocked(options.url)
         logger.err(string.format(
             "Zlibrary:Api.makeHttpRequest - %s answered a bot-check page with status %s, not the API",
             tostring(options.url), tostring(result.status_code)))

--- a/zlibrary/config.lua
+++ b/zlibrary/config.lua
@@ -33,7 +33,16 @@ Config.SETTINGS_TIMEOUT_POPULAR_KEY = "zlibrary_timeout_popular"
 Config.SETTINGS_TIMEOUT_DOWNLOAD_KEY = "zlibrary_timeout_download"
 Config.SETTINGS_TIMEOUT_COVER_KEY = "zlibrary_timeout_cover"
 Config.SETTINGS_TIMEOUT_BOOK_COMMENTS_KEY = "zlibrary_timeout_book_comments"
+Config.SETTINGS_BLOCKED_MIRRORS_KEY = "zlibrary_blocked_mirrors"
 Config.CREDENTIALS_FILENAME = "zlibrary_credentials.lua"
+
+-- How long a mirror that answered a request with a bot-check page stays skipped by discovery.
+-- Deliberately long: a mirror put behind a WAF tends to stay there, and re-selecting it sooner just
+-- reproduces the failed request the user already saw. The cost of over-skipping a mirror that has
+-- since recovered is small -- there are dozens of other seeds plus the dynamic domain list, and
+-- getSeedUrls falls back to the blocked ones if every candidate is blocked -- so err towards a long
+-- block rather than a short one. Not permanent, so a recovered mirror is eventually retried.
+Config.BLOCKED_MIRROR_TTL = 180 * 24 * 3600 -- ~6 months
 
 Config.DEFAULT_DOWNLOAD_DIR_FALLBACK = G_reader_settings:readSetting("home_dir")
              or require("apps/filemanager/filemanagerutil").getDefaultDir()
@@ -505,38 +514,92 @@ function Config.getBaseUrl(is_original)
     return configured_url
 end
 
+-- Mirrors that answered a request with a bot-check page instead of the API. Discovery skips them so
+-- a server that passes /eapi/info/ok but blocks /eapi/book/search (observed on tw.101d.by) is not
+-- selected again on every sweep. Keyed by scheme://host[:port], so the path of the challenged
+-- request does not matter and a match with a bare seed URL is stable; entries expire after
+-- BLOCKED_MIRROR_TTL.
+local function _normalizeMirrorKey(url)
+    if type(url) ~= "string" or url == "" then return nil end
+    local parsed = socket_url.parse(url)
+    if parsed and parsed.host and parsed.host ~= "" then
+        local key = (parsed.scheme or "https") .. "://" .. parsed.host:lower()
+        if parsed.port then key = key .. ":" .. parsed.port end
+        return key
+    end
+    -- Fall back to a crude strip so even a malformed URL yields a stable key.
+    return (url:gsub("[/?#].*$", ""))
+end
+
+function Config.markMirrorBlocked(url, now)
+    local key = _normalizeMirrorKey(url)
+    if not key then return end
+    now = now or os.time()
+    local map = Config.getSetting(Config.SETTINGS_BLOCKED_MIRRORS_KEY)
+    if type(map) ~= "table" then map = {} end
+    -- Drop aged-out entries while we are here so the map cannot grow without bound.
+    for k, ts in pairs(map) do
+        if type(ts) ~= "number" or (now - ts) >= Config.BLOCKED_MIRROR_TTL then
+            map[k] = nil
+        end
+    end
+    map[key] = now
+    Config.saveSetting(Config.SETTINGS_BLOCKED_MIRRORS_KEY, map)
+end
+
+function Config.isMirrorBlocked(url, now)
+    local key = _normalizeMirrorKey(url)
+    if not key then return false end
+    local map = Config.getSetting(Config.SETTINGS_BLOCKED_MIRRORS_KEY)
+    if type(map) ~= "table" then return false end
+    local ts = map[key]
+    if type(ts) ~= "number" then return false end
+    now = now or os.time()
+    return (now - ts) < Config.BLOCKED_MIRROR_TTL
+end
+
 function Config.getSeedUrls()
     local new_seed_urls, seen = {}, {}
+    -- Seeds that would have been included but are currently bot-blocked. Kept only for the fallback
+    -- below: if every candidate is blocked, trying them beats leaving discovery with nothing.
+    local blocked_bucket = {}
 
     local base = Config.getBaseUrl()
     local clean_base = (type(base) == "string" and base ~= "") and base:gsub("/$", "") or nil
     if clean_base then seen[clean_base] = true end
 
+    local function shuffle(t)
+        for i = #t, 2, -1 do
+            local j = math.random(i)
+            t[i], t[j] = t[j], t[i]
+        end
+    end
+
     local function processAndMerge(source_urls , src_name)
         if type(source_urls) ~= "table" or #source_urls == 0 then return end
-        local temp_urls = {}
-        
+        local temp_urls, blocked_temp = {}, {}
+
         -- clean & deduplicate
         for _, url in ipairs(source_urls) do
             if type(url) == "string" and url ~= "" then
                 local clean_url = url:gsub("/$", "")
                 if not clean_url:match("^https?://") then
-                    clean_url  = "https://" .. clean_url 
+                    clean_url  = "https://" .. clean_url
                 end
                 if not seen[clean_url] then
                     seen[clean_url] = true
-                    table.insert(temp_urls, {url = clean_url, src = src_name})
+                    if Config.isMirrorBlocked(clean_url) then
+                        table.insert(blocked_temp, {url = clean_url, src = src_name})
+                    else
+                        table.insert(temp_urls, {url = clean_url, src = src_name})
+                    end
                 end
             end
         end
-        -- Shuffle
-        for i = #temp_urls, 2, -1 do
-            local j = math.random(i)
-            temp_urls[i], temp_urls[j] = temp_urls[j], temp_urls[i]
-        end
-        for _, item in ipairs(temp_urls) do
-            table.insert(new_seed_urls, item)
-        end
+        shuffle(temp_urls)
+        shuffle(blocked_temp)
+        for _, item in ipairs(temp_urls) do table.insert(new_seed_urls, item) end
+        for _, item in ipairs(blocked_temp) do table.insert(blocked_bucket, item) end
     end
 
     -- User-defined  > Hardcoded > Dynamic
@@ -546,7 +609,12 @@ function Config.getSeedUrls()
     local domains_cache = Cache:new{ name = "_domains_cache" }
     -- domains are updated passively, no expiration set here
     processAndMerge(domains_cache:get("domains"), "D")
-    
+
+    -- Never hand discovery an empty list purely because everything is blocked right now.
+    if #new_seed_urls == 0 then
+        for _, item in ipairs(blocked_bucket) do table.insert(new_seed_urls, item) end
+    end
+
     return new_seed_urls
 end
 

--- a/zlibrary/discovery.lua
+++ b/zlibrary/discovery.lua
@@ -20,6 +20,21 @@ local Ui = require("zlibrary.ui")
 local T = require("zlibrary.gettext")
 local logger = require("logger")
 
+-- Pick a URL at random from the k fastest working mirrors. Selecting the single quickest every time
+-- lands the reader on the same mirror on every sweep; spreading the choice over the top few keeps it
+-- varied (and spreads load) while still avoiding the slow ones. Sorts a copy, so the caller's list is
+-- left alone; a mirror that reported no timing sorts last.
+local function _pickFastestRandom(candidates, k)
+    if type(candidates) ~= "table" or #candidates == 0 then return nil end
+    local sorted = {}
+    for _, c in ipairs(candidates) do sorted[#sorted + 1] = c end
+    table.sort(sorted, function(a, b)
+        return (a.elapsed or math.huge) < (b.elapsed or math.huge)
+    end)
+    local n = math.min(k or 5, #sorted)
+    return sorted[math.random(n)].url
+end
+
 local Discovery = {}
 
 function Discovery.run(self, is_interactive, retry_callback)
@@ -113,6 +128,10 @@ function Discovery.run(self, is_interactive, retry_callback)
         -- stale threshold from the previous run would sit below everything the next one
         -- measures and no mirror would ever displace it.
         local best_elapsed = nil
+        -- Every working mirror this run, with its timing. On the interactive path the final choice is
+        -- made from the fastest few of these (see on_batch_end), so discovery does not settle on the
+        -- same single quickest mirror every sweep.
+        local working = {}
         -- task status lock
         local is_discovering = false
         local max_idx = 1
@@ -163,7 +182,8 @@ function Discovery.run(self, is_interactive, retry_callback)
             is_discovering = true
             first_working_url = nil
             best_elapsed = nil
-            
+            working = {}
+
             resetAllItems()
             self.discover_channel:executeBatch({
                 items = valid_seeds,
@@ -242,16 +262,19 @@ function Discovery.run(self, is_interactive, retry_callback)
                                 first_working_url = seed.url
                                 return true
                             end
-                        elseif not first_working_url
-                                or (result.elapsed and (not best_elapsed or result.elapsed < best_elapsed)) then
+                        else
                             -- Nothing is aborted here: the menu shows a verdict per row, so the
-                            -- interactive sweep probes every seed either way and has already paid
-                            -- for the timings. Spend them -- getSeedUrls shuffles, so the first
-                            -- responder is an arbitrary mirror, while the quickest is a defensible
-                            -- one. A working mirror with no elapsed still beats having no URL,
-                            -- which is why the first clause stands on its own.
-                            first_working_url = seed.url
-                            best_elapsed = result.elapsed or best_elapsed
+                            -- interactive sweep probes every seed either way and has already paid for
+                            -- the timings. Collect every working mirror; on_batch_end makes the final
+                            -- choice from the fastest few, so discovery is not pinned to one mirror
+                            -- every sweep. Keep tracking the quickest too, as a fallback for the case
+                            -- where the batch ends before the override can run.
+                            working[#working + 1] = { url = seed.url, elapsed = result.elapsed }
+                            if not first_working_url
+                                    or (result.elapsed and (not best_elapsed or result.elapsed < best_elapsed)) then
+                                first_working_url = seed.url
+                                best_elapsed = result.elapsed or best_elapsed
+                            end
                         end
                     end
                     return false
@@ -265,6 +288,12 @@ function Discovery.run(self, is_interactive, retry_callback)
                             end
                         end
                         if next(filtered_results) then check_cache:insert("result", filtered_results) end
+                    end
+                    -- Choose from the fastest few rather than always the single quickest, so repeated
+                    -- sweeps do not keep landing on the same mirror. The current base is already out of
+                    -- the running (getSeedUrls drops it), so this never re-picks the one in use.
+                    if is_interactive and #working > 0 then
+                        first_working_url = _pickFastestRandom(working, 5) or first_working_url
                     end
                     finishDiscovery()
                 end,

--- a/zlibrary/download.lua
+++ b/zlibrary/download.lua
@@ -130,6 +130,7 @@ local function _refreshFileManagerListing()
         local FileManager = require("apps/filemanager/filemanager")
         if FileManager.instance then
             FileManager.instance:onRefresh()
+            UIManager:setDirty(FileManager.instance, "ui")
         end
     end)
 end

--- a/zlibrary/menu.lua
+++ b/zlibrary/menu.lua
@@ -92,7 +92,24 @@ end
 
 function M:_updateCoverItems(select_number, no_recalculate_dimen)
     if not self.show_cover then return end
-    if not self.item_table or self.items_max_lines then return end
+    if not self.item_table then return end
+
+    -- Every Menu:updateItems frees the widgets embedded in the item rows
+    -- (VerticalGroup:clear -> free, recursively), and MenuItem embeds
+    -- item.state directly. Since item.state lives on the item_table, which
+    -- outlives the rows, anything left there afterwards is a *freed* widget --
+    -- and painting one crashes with "attempt to index field '_bb' (a nil
+    -- value)". Rebuilding only the current page therefore is not enough: any
+    -- item skipped, on another page, or missed because of an early return
+    -- below keeps a dangling widget that KOReader will happily re-embed.
+    --
+    -- So drop every reference first, then rebuild just what this page needs.
+    -- A nil state is safe: MenuItem falls back to a HorizontalSpan.
+    for _, item in ipairs(self.item_table) do
+        item.state = nil
+    end
+
+    if self.items_max_lines then return end
     local perpage = self.perpage
     local current_page = self.page
     local idx_offset = (current_page - 1) * perpage


### PR DESCRIPTION
## 1.0.47

### Fixed

**Browsing book lists with covers no longer crashes on fast page turns.** In cover (grid) view,
turning the page while covers were still loading could crash KOReader with an *"attempt to index
field '_bb'"* error. Each cover slot is now cleared properly between refreshes, so a cover image that
was already freed can no longer be painted again.

**Auto-discovery stops re-picking a server that can't actually search.** Some mirrors answer the
health check but block the real search behind an anti-bot page (*"This Z-library server is refusing
automated access"*) — and auto-discovery kept choosing the same one every sweep. When a server
answers any request with such a page it is now remembered and skipped by discovery, so the next
sweep moves on to a working mirror. The block lasts a good while but is not permanent, so a mirror
that later drops its anti-bot wall is eventually tried again.

**Auto-discovery no longer settles on the same server every time.** *Auto-discover base URL* used to
pick the single fastest mirror, so repeated runs kept landing on the same one; it now chooses at
random among the fastest few, spreading the load. (The server you are currently on is already left
out of the running, so discovery never just re-picks it.)