### PR TITLE
fix: sign in via rpc.php, not the broken /eapi/user/login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ is summarised rather than listed; the commit history has the detail.
 The version number is set by the release workflow, which bumps the patch version on every push
 to `main` — so the top section is the one about to ship.
 
+## 1.0.48
+
+### Fixed
+
+**Signing in works again.** Z-library's `/eapi/user/login` API began rejecting valid credentials with
+*"Authorization failed"*, which broke sign-in — and with it downloads, My Books and anything else
+that needs an account — for everyone using the plugin. The plugin now signs in the same way the
+website and the official desktop app do: a form POST to `/rpc.php`, which accepts your normal email
+and password (no browser or extra steps needed). A genuinely wrong password still reports *"Incorrect
+email or password"* and can be corrected in place, exactly as before.
+
 ## 1.0.47
 
 ### Fixed

--- a/test/base_url_harness.lua
+++ b/test/base_url_harness.lua
@@ -106,7 +106,7 @@ r.check("default base URL has no trailing slash",
         Config.getBaseUrl() == "https://z-lib.fo",
         "got " .. tostring(Config.getBaseUrl()))
 r.check("login URL is built without a double slash",
-        Config.getLoginUrl() == "https://z-lib.fo/eapi/user/login",
+        Config.getLoginUrl() == "https://z-lib.fo/rpc.php",
         "got " .. tostring(Config.getLoginUrl()))
 
 -- ---------------------------------------------------------------- setAndValidateBaseUrl

--- a/test/rpc_login_harness.lua
+++ b/test/rpc_login_harness.lua
@@ -1,0 +1,107 @@
+-- Login goes through rpc.php (action=login), not /eapi/user/login.
+--
+-- The old endpoint answers valid credentials with "Authorization failed"; the website (and the
+-- desktop app's login webview) use rpc.php with a plain form POST -- no CSRF token, no prior cookie
+-- (verified against the live server). rpc.php returns the session under `response`:
+--   success      -> {"errors":[],"response":{"user_id":21699629,"user_key":"..."}}
+--   wrong creds  -> {"errors":[],"response":{"validationError":true,"message":"Incorrect email or password"}}
+--
+-- Drives the real Api.login over a stubbed socket.http so the request it builds (endpoint + fields)
+-- and the way it reads those two shapes are tested as they actually run.
+
+local PLUGIN = assert(arg[1], "usage: luajit rpc_login_harness.lua <plugin-root> <luasocket-src>")
+local LUASOCKET = assert(arg[2], "usage: luajit rpc_login_harness.lua <plugin-root> <luasocket-src>")
+
+package.path = PLUGIN .. "/?.lua;" .. package.path
+local support = dofile(PLUGIN .. "/test/support.lua")
+support.preload_socket(LUASOCKET)
+support.preload_koreader_stubs()
+local r = support.reporter()
+
+package.preload["zlibrary.config"] = function()
+    return {
+        USER_AGENT = "UA",
+        getBaseUrl = function() return "https://z-lib.example" end,
+        getLoginUrl = function() return "https://z-lib.example/rpc.php" end,
+        getLoginTimeout = function() return { 10, 15 } end,
+        -- makeHttpRequest collaborators (redirect cache + bot-block memory); no-ops here.
+        setCacheRealUrl = function() end,
+        getCacheRealUrl = function() return nil end,
+        clearCacheRealUrlIfPinned = function() return false end,
+        markMirrorBlocked = function() end,
+    }
+end
+
+-- json.decode is a lookup keyed by the body the socket emits (the support stub refuses to parse).
+local BODIES = {
+    ok       = { errors = {}, response = { user_id = 21699629, user_key = "f34263e7cd15732f40dcb9850f8c6cef" } },
+    wrong_pw = { errors = {}, response = { validationError = true, fields = { "email", "password" }, message = "Incorrect email or password" } },
+    other    = { errors = { "Service temporarily unavailable" }, response = {} },
+}
+package.preload["json"] = function()
+    return { decode = setmetatable({ simple = {} }, { __call = function(_, s)
+        local v = BODIES[s]
+        if not v then error("parse error: " .. tostring(s)) end
+        return v
+    end }) }
+end
+
+local last
+local serve
+package.preload["socket.http"] = function()
+    return { request = function(p)
+        -- Drain the ltn12 body source so the request body can be asserted.
+        local body = ""
+        if p.source then while true do local c = p.source(); if not c then break end; body = body .. c end end
+        last = { url = p.url, method = p.method, body = body, headers = p.headers }
+        if p.sink then p.sink(serve) end
+        return 1, 200, {}, "HTTP/1.1 200"
+    end }
+end
+local Api = require("zlibrary.api")
+
+local function login_returning(key)
+    serve = key
+    return Api.login("reader@example.com", "correct horse")
+end
+
+-- ---------------------------------------------------------------- the request it builds
+login_returning("ok")
+r.check("login posts to rpc.php", last.url == "https://z-lib.example/rpc.php", "url = " .. tostring(last.url))
+r.check("login is a POST", last.method == "POST", "method = " .. tostring(last.method))
+r.check("the body carries action=login", last.body:find("action=login", 1, true) ~= nil, last.body)
+r.check("the body carries the extra rpc fields",
+        last.body:find("gg_json_mode=1", 1, true) and last.body:find("site_mode=books", 1, true)
+            and last.body:find("isModal=true", 1, true), last.body)
+r.check("the body carries the credentials",
+        last.body:find("email=", 1, true) and last.body:find("password=", 1, true), last.body)
+
+-- ---------------------------------------------------------------- success (session under `response`)
+local res = login_returning("ok")
+r.check("a successful login returns the session from `response`",
+        res.error == nil and res.user_id == "21699629" and res.user_key == "f34263e7cd15732f40dcb9850f8c6cef",
+        "error=" .. tostring(res.error) .. " id=" .. tostring(res.user_id) .. " key=" .. tostring(res.user_key))
+
+-- ---------------------------------------------------------------- wrong password
+res = login_returning("wrong_pw")
+r.check("a wrong password surfaces the server's message",
+        res.error == "Incorrect email or password" and res.user_id == nil,
+        "error = " .. tostring(res.error))
+r.check("and it is classified as a credential rejection (so it can be fixed in place)",
+        Api.isCredentialRejection(res.error) == true, "not a rejection")
+
+-- ---------------------------------------------------------------- some other server error
+res = login_returning("other")
+r.check("an errors[] entry with no session is surfaced as the error",
+        res.error == "Service temporarily unavailable" and res.user_id == nil,
+        "error = " .. tostring(res.error))
+r.check("and an unrelated error is not a credential rejection",
+        Api.isCredentialRejection(res.error) == false, "wrongly a rejection")
+
+-- ---------------------------------------------------------------- wiring
+local function slurp(p) local fh = assert(io.open(p)); local s = fh:read("*a"); fh:close(); return s end
+r.check("getLoginUrl points at rpc.php",
+        slurp(PLUGIN .. "/zlibrary/config.lua"):find("/rpc.php", 1, true) ~= nil,
+        "config.lua no longer builds the rpc.php login URL")
+
+r.finish()

--- a/zlibrary/api.lua
+++ b/zlibrary/api.lua
@@ -685,6 +685,7 @@ function Api.login(email, password, is_redir_callback)
     logger.info(string.format("Zlibrary:Api.login - START"))
     local result = { user_id = nil, user_key = nil, error = nil }
 
+    local base = Config.getBaseUrl()
     local login_url = Config.getLoginUrl()
     if not login_url then
         result.error = T("The Z-library server address (URL) is not set. Please configure it in the Z-library plugin settings.")
@@ -692,15 +693,18 @@ function Api.login(email, password, is_redir_callback)
         return result
     end
 
-    local body_data = {
-        email = email or "",
-        password = password or "",
-    }
-    local body_parts = {}
-    for k, v in pairs(body_data) do
-        table.insert(body_parts, util.urlEncode(k) .. "=" .. util.urlEncode(v))
-    end
-    local body = table.concat(body_parts, "&")
+    -- rpc.php's login action, exactly as the website sends it: the extra fields (action, site_mode,
+    -- gg_json_mode, isModal, redirectUrl) are what make it return the session as JSON rather than an
+    -- HTML redirect, and no CSRF token or prior cookie is needed (verified against the live server).
+    local body = table.concat({
+        "isModal=true",
+        "email=" .. util.urlEncode(email or ""),
+        "password=" .. util.urlEncode(password or ""),
+        "site_mode=books",
+        "action=login",
+        "gg_json_mode=1",
+        "redirectUrl=" .. util.urlEncode((base or "") .. "/"),
+    }, "&")
 
     local http_result = Api.makeHttpRequest{
         url = login_url,
@@ -710,6 +714,8 @@ function Api.login(email, password, is_redir_callback)
             ["Accept"] = "application/json, text/javascript, */*; q=0.01",
             ["User-Agent"] = Config.USER_AGENT,
             ["X-Requested-With"] = "XMLHttpRequest",
+            ["Origin"] = base,
+            ["Referer"] = base and (base .. "/") or nil,
             ["Content-Length"] = tostring(#body),
         },
         body = body,
@@ -741,38 +747,38 @@ function Api.login(email, password, is_redir_callback)
         return result
     end
 
-    local success_flag = tonumber(data.success) or 0
-    local session = data.user or data.response or {}
-
-    if success_flag ~= 1 then
-        -- data.error may be a string or an object; guard the index the way Api.search does, or a
-        -- structured error surfaces as "table: 0x..." -- which also defeats isCredentialRejection.
-        local api_message = (type(data.error) == "table" and data.error.message) or data.error or
-                           (type(session) == "table" and session.message) or
-                           data.message
-        result.error = api_message and tostring(api_message) or (http_result.error or T("Login failed"))
-        logger.warn(string.format("Zlibrary:Api.login - END (API error) - Error: %s", result.error))
-        return result
-    end
-
-    if type(session) ~= "table" then
-        result.error = T("Login failed: Invalid session data")
-        logger.warn(string.format("Zlibrary:Api.login - END (Session error) - Error: %s", result.error))
-        return result
-    end
-
+    -- rpc.php returns the session under `response` on success --
+    --   {"errors":[],"response":{"user_id":21699629,"user_key":"..."}}
+    -- and a validation error there on bad credentials --
+    --   {"errors":[],"response":{"validationError":true,"message":"Incorrect email or password"}}
+    -- so read the session first and only treat the reply as a failure when no session is present.
+    -- data.user is kept as a fallback for the older /eapi shape ({user:{id,remix_userkey}}).
+    local session = (type(data.response) == "table" and data.response)
+                 or (type(data.user) == "table" and data.user) or {}
     local user_id = tostring(session.id or session.user_id or "")
     local user_key = session.remix_userkey or session.user_key or ""
 
-    if user_id == "" or user_key == "" then
-        result.error = T("Login failed") .. ": " .. (session.message or data.message or Api.CREDENTIALS_REJECTED_TEXT)
-        logger.warn(string.format("Zlibrary:Api.login - END (Credentials error) - Error: %s", result.error))
+    if user_id ~= "" and user_key ~= "" then
+        result.user_id = user_id
+        result.user_key = user_key
+        logger.info(string.format("Zlibrary:Api.login - END (Success) - UserID: %s", result.user_id))
         return result
     end
 
-    result.user_id = user_id
-    result.user_key = user_key
-    logger.info(string.format("Zlibrary:Api.login - END (Success) - UserID: %s", result.user_id))
+    -- No session: surface the server's message. session.message carries rpc.php's wording
+    -- ("Incorrect email or password"), which Api.isCredentialRejection matches so a wrong password is
+    -- corrected in place. Guard every error index the way Api.search does, or a structured error
+    -- surfaces as "table: 0x..." and defeats that classifier.
+    local errors = data.errors
+    local api_message = session.message
+        or (type(data.error) == "table" and data.error.message) or data.error
+        or (type(errors) == "table" and type(errors[1]) == "table" and errors[1].message)
+        or (type(errors) == "table" and type(errors[1]) == "string" and errors[1])
+        or data.message
+    result.error = (api_message and tostring(api_message))
+        or http_result.error
+        or (T("Login failed") .. ": " .. Api.CREDENTIALS_REJECTED_TEXT)
+    logger.warn(string.format("Zlibrary:Api.login - END (API error) - Error: %s", result.error))
     return result
 end
 

--- a/zlibrary/config.lua
+++ b/zlibrary/config.lua
@@ -653,7 +653,10 @@ end
 function Config.getLoginUrl()
     local base = Config.getBaseUrl()
     if not base then return nil end
-    return base .. "/eapi/user/login"
+    -- The website signs in through rpc.php (action=login), not /eapi/user/login: the latter now
+    -- answers valid credentials with "Authorization failed" (confirmed on device and against the
+    -- live API), while rpc.php works with a plain form POST.
+    return base .. "/rpc.php"
 end
 
 function Config.getSearchUrl()


### PR DESCRIPTION
Z-library's /eapi/user/login now answers valid credentials with "Authorization failed" (confirmed on device and against the live API), which broke sign-in -- and downloads, My Books, etc. -- for everyone. The website and the official desktop app sign in through rpc.php instead.

Verified against the live server (articles.sk): a plain form POST to /rpc.php with action=login (+ isModal, site_mode, gg_json_mode, redirectUrl) returns the session as JSON, with NO CSRF token or prior cookie required:
  success     -> {"errors":[],"response":{"user_id":..,"user_key":".."}}
  wrong creds -> {"errors":[],"response":{"validationError":true,
                  "message":"Incorrect email or password"}}

Changes:
- Config.getLoginUrl -> <base>/rpc.php.
- Api.login sends the rpc.php login form (with Origin/Referer) and reads the session from `response` first, only treating the reply as a failure when it carries no user_id/user_key. The wrong-password wording is the same "Incorrect email or password" Api.isCredentialRejection already matches, so a bad password is still correctable in place. data.user is kept as a fallback for the old shape.

Test: rpc_login_harness drives the real Api.login over a stubbed socket.http -- it posts action=login to rpc.php, reads the session on success, surfaces "Incorrect email or password" (a rejection) on bad creds, and surfaces other errors[]. base_url_harness updated for the new login URL.